### PR TITLE
Implement XNAIndicator class and add corresponding UISettings fields

### DIFF
--- a/Rampastring.XNAUI.csproj
+++ b/Rampastring.XNAUI.csproj
@@ -154,6 +154,7 @@
     <Compile Include="RMath.cs" />
     <Compile Include="SoundPlayer.cs" />
     <Compile Include="XNAControls\ControlDrawMode.cs" />
+    <Compile Include="XNAControls\XNAIndicator.cs" />
     <Compile Include="XNAControls\XNALinkLabel.cs" />
     <Compile Include="XNAControls\XNAListBoxItem.cs" />
     <Compile Include="XNAControls\XNAPasswordBox.cs" />

--- a/UISettings.cs
+++ b/UISettings.cs
@@ -1,6 +1,5 @@
-﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using System.Collections.Generic;
 
 namespace Rampastring.XNAUI
 {
@@ -41,10 +40,6 @@ namespace Rampastring.XNAUI
         public Texture2D CheckBoxDisabledCheckedTexture { get; set; }
 
         public Texture2D CheckBoxDisabledClearTexture { get; set; }
-
-        public Dictionary<string, Texture2D> IndicatorTextures { get; set; }
-
-        public string IndicatorInitialTextureKey { get; set; }
 
         public float DefaultAlphaRate = 0.005f;
 

--- a/UISettings.cs
+++ b/UISettings.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
+using System.Collections.Generic;
 
 namespace Rampastring.XNAUI
 {
@@ -41,8 +42,14 @@ namespace Rampastring.XNAUI
 
         public Texture2D CheckBoxDisabledClearTexture { get; set; }
 
+        public Dictionary<string, Texture2D> IndicatorTextures { get; set; }
+
+        public string IndicatorInitialTextureKey { get; set; }
+
         public float DefaultAlphaRate = 0.005f;
 
         public float CheckBoxAlphaRate = 0.05f;
+
+        public float IndicatorAlphaRate = 0.05f;
     }
 }

--- a/XNAControls/XNAIndicator.cs
+++ b/XNAControls/XNAIndicator.cs
@@ -29,13 +29,13 @@ namespace Rampastring.XNAUI.XNAControls
         /// </summary>
         public Dictionary<T, Texture2D> Textures { get; set; }
 
-        protected Texture2D _oldTexture = null;
-        protected Texture2D _currentTexture = null;
+        private Texture2D _oldTexture = null;
+        private Texture2D _currentTexture = null;
 
         /// <summary>
         /// Determines the currently displayed texture.
         /// </summary>
-        protected Texture2D CurrentTexture
+        protected virtual Texture2D CurrentTexture
         {
             get => _currentTexture;
             set
@@ -223,7 +223,7 @@ namespace Rampastring.XNAUI.XNAControls
                 DrawTexture(_oldTexture,
                     new Rectangle(0, indicatorYPosition,
                     _oldTexture.Width, _oldTexture.Height),
-                    Color.White * (float)textureAlpha);
+                    Color.White);
             }
 
             // Don't draw new texture if it's fully invisible

--- a/XNAControls/XNAIndicator.cs
+++ b/XNAControls/XNAIndicator.cs
@@ -1,0 +1,246 @@
+﻿using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Audio;
+using Microsoft.Xna.Framework.Graphics;
+using Rampastring.Tools;
+using System;
+using System.Collections.Generic;
+
+namespace Rampastring.XNAUI.XNAControls
+{
+    /// <summary>
+    /// An indicator with dynamic textures pool.
+    /// </summary>
+    public class XNAIndicator : XNAControl
+    {
+        private const int TEXT_PADDING_DEFAULT = 5;
+
+        /// <summary>
+        /// Creates a new indicator.
+        /// </summary>
+        /// <param name="windowManager">The window manager.</param>
+        public XNAIndicator(WindowManager windowManager) : base(windowManager)
+        {
+            AlphaRate = UISettings.ActiveSettings.IndicatorAlphaRate * 2.0;
+        }
+
+        /// <summary>
+        /// Contains a pool of textures for indicator.
+        /// </summary>
+        public Dictionary<string, Texture2D> Textures { get; set; }
+
+
+        protected Texture2D _oldTexture = null;
+        protected Texture2D _currentTexture = null;
+
+        /// <summary>
+        /// Determines the currently displayed texture.
+        /// </summary>
+        protected Texture2D CurrentTexture
+        {
+            get { return _currentTexture; }
+            set
+            {
+                if (value != _currentTexture)
+                {
+                    _oldTexture = _currentTexture;
+                    _currentTexture = value;
+                    textureAlpha = 0.0;
+                }
+            }
+        }
+
+        /// <summary>
+        /// The index of the text font.
+        /// </summary>
+        public int FontIndex { get; set; }
+
+        /// <summary>
+        /// The space, in pixels, between the indicator and its text.
+        /// </summary>
+        public int TextPadding { get; set; } = TEXT_PADDING_DEFAULT;
+
+        private Color? _idleColor;
+
+        /// <summary>
+        /// The color of the indicator's text when it's not hovered on.
+        /// </summary>
+        public Color IdleColor
+        {
+            get => _idleColor ?? UISettings.ActiveSettings.TextColor;
+            set { _idleColor = value; }
+        }
+
+        private Color? _highlightColor;
+
+        /// <summary>
+        /// The color of the indicator's text when it's hovered on.
+        /// </summary>
+        public Color HighlightColor
+        {
+            get => _highlightColor ?? UISettings.ActiveSettings.AltColor;
+            set
+            { _highlightColor = value; }
+        }
+
+        public double AlphaRate { get; set; }
+
+        /// <summary>
+        /// Gets or sets the text of the indicator.
+        /// </summary>
+        public override string Text
+        {
+            get
+            {
+                return base.Text;
+            }
+
+            set
+            {
+                base.Text = value;
+                SetTextPositionAndSize();
+            }
+        }
+
+        /// <summary>
+        /// The Y coordinate of the indicator text
+        /// relative to the location of the indicator.
+        /// </summary>
+        protected int TextLocationY { get; set; }
+
+
+        private double textureAlpha = 1.0;
+
+
+        public override void Initialize()
+        {
+            if (Textures == null || Textures.Count == 0)
+                Textures = UISettings.ActiveSettings.IndicatorTextures;
+
+            if (_oldTexture == null)
+                _oldTexture = Textures[UISettings.ActiveSettings.IndicatorInitialTextureKey];
+
+            if (_currentTexture == null)
+                _currentTexture = Textures[UISettings.ActiveSettings.IndicatorInitialTextureKey];
+
+            SetTextPositionAndSize();
+
+            base.Initialize();
+        }
+
+        public void SwitchTexture(string key)
+        {
+            if (Textures.ContainsKey(key))
+            {
+                CurrentTexture = Textures[key];
+            }
+            else
+            {
+                Logger.Log("XNAIndicator: Tried to switch to non-existing texture " + key + "at indicator " + Name +  "!");
+            }
+        }
+
+        protected override void ParseAttributeFromINI(IniFile iniFile, string key, string value)
+        {
+            switch (key)
+            {
+                case "FontIndex":
+                    FontIndex = Conversions.IntFromString(value, 0);
+                    return;
+                case "HighlightColor":
+                    HighlightColor = AssetLoader.GetColorFromString(value);
+                    return;
+                case "AlphaRate":
+                    AlphaRate = Conversions.DoubleFromString(value, AlphaRate);
+                    return;
+            }
+
+            base.ParseAttributeFromINI(iniFile, key, value);
+        }
+
+        /// <summary>
+        /// Updates the size of the indicator and the vertical position of its text.
+        /// </summary>
+        protected virtual void SetTextPositionAndSize()
+        {
+            if (Textures == null || Textures.Count == 0)
+                return;
+
+            var enumerator = Textures.Values.GetEnumerator();
+            enumerator.MoveNext();
+            Texture2D texture2D = enumerator.Current;
+
+            if (!string.IsNullOrEmpty(Text))
+            {
+                Vector2 textDimensions = Renderer.GetTextDimensions(Text, FontIndex);
+
+                TextLocationY = (texture2D.Height - (int)textDimensions.Y) / 2 - 1;
+
+                Width = (int)textDimensions.X + TEXT_PADDING_DEFAULT + texture2D.Width;
+                Height = Math.Max((int)textDimensions.Y, texture2D.Height);
+            }
+            else
+            {
+                Width = texture2D.Width;
+                Height = texture2D.Height;
+            }
+        }
+
+        /// <summary>
+        /// Updates the indicator's alpha each frame.
+        /// </summary>
+        public override void Update(GameTime gameTime)
+        {
+            double alphaRate = AlphaRate * (gameTime.ElapsedGameTime.TotalMilliseconds / 10.0);
+            textureAlpha = Math.Min(textureAlpha + alphaRate, 1.0);
+            
+            base.Update(gameTime);
+        }
+
+        /// <summary>
+        /// Draws the indicator.
+        /// </summary>
+        public override void Draw(GameTime gameTime)
+        {
+            int checkBoxYPosition = 0;
+            int textYPosition = TextLocationY;
+
+            if (TextLocationY < 0)
+            {
+                // If the text is higher than the checkbox texture (textLocationY < 0), 
+                // let's draw the text at the top of the client
+                // rectangle and the check-box in the middle of the text.
+                // This is necessary for input to work properly.
+                checkBoxYPosition -= TextLocationY;
+                textYPosition = 0;
+            }
+
+            if (!string.IsNullOrEmpty(Text))
+            {
+                Color textColor = IsActive ? HighlightColor : IdleColor;
+
+                DrawStringWithShadow(Text, FontIndex,
+                    new Vector2(CurrentTexture.Width + TextPadding, textYPosition),
+                    textColor);
+            }
+
+            // Don't draw old texture if new one is fully opaque
+            if (textureAlpha < 1.0)
+            {
+                DrawTexture(_oldTexture,
+                    new Rectangle(0, checkBoxYPosition,
+                    _oldTexture.Width, _oldTexture.Height), Color.White);
+            }
+
+            // Don't draw new texture if it's fully invisible
+            if (textureAlpha > 0.0)
+            {
+                DrawTexture(_currentTexture,
+                    new Rectangle(0, checkBoxYPosition,
+                    _currentTexture.Width, _currentTexture.Height),
+                    new Color(255, 255, 255, (int)(textureAlpha * 255)));
+            }
+
+            base.Draw(gameTime);
+        }
+    }
+}

--- a/XNAControls/XNAIndicator.cs
+++ b/XNAControls/XNAIndicator.cs
@@ -103,9 +103,7 @@ namespace Rampastring.XNAUI.XNAControls
         /// </summary>
         protected int TextLocationY { get; set; }
 
-
         private double textureAlpha = 1.0;
-
 
         public override void Initialize()
         {
@@ -127,7 +125,7 @@ namespace Rampastring.XNAUI.XNAControls
         /// Switches the texture of the indicator.
         /// </summary>
         /// <param name="key">The enum texture key.</param>
-        public void SwitchTexture(T key)
+        public virtual void SwitchTexture(T key)
         {
             if (Textures.ContainsKey(key))
                 CurrentTexture = Textures[key];

--- a/XNAControls/XNAIndicator.cs
+++ b/XNAControls/XNAIndicator.cs
@@ -1,4 +1,4 @@
-using Microsoft.Xna.Framework;
+﻿using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.Tools;
 using System;
@@ -224,7 +224,8 @@ namespace Rampastring.XNAUI.XNAControls
             {
                 DrawTexture(_oldTexture,
                     new Rectangle(0, indicatorYPosition,
-                    _oldTexture.Width, _oldTexture.Height), Color.White);
+                    _oldTexture.Width, _oldTexture.Height),
+                    Color.White * (float)textureAlpha);
             }
 
             // Don't draw new texture if it's fully invisible
@@ -233,7 +234,7 @@ namespace Rampastring.XNAUI.XNAControls
                 DrawTexture(_currentTexture,
                     new Rectangle(0, indicatorYPosition,
                     _currentTexture.Width, _currentTexture.Height),
-                    new Color(255, 255, 255, (int)(textureAlpha * 255)));
+                    Color.White * (float)textureAlpha);
             }
 
             base.Draw(gameTime);


### PR DESCRIPTION
Code derived from XNACheckbox. Indicator is a multi-state element that displays status of, for example, a player in game room (ingame, not ready, ready, etc.). It uses a dynamic pool of textures, and switching is done via changing the texture by key. It also needs a pool of textures to be supplied, with a default texture key.

Custom UISettings fields:

```
public Dictionary<string, Texture2D> IndicatorTextures { get; set; }
public string IndicatorInitialTextureKey { get; set; }
public float IndicatorAlphaRate = 0.05f; 
```