### PR TITLE
Separate XNATabControl text color for disabled / unselectable state

### DIFF
--- a/XNAControls/XNATabControl.cs
+++ b/XNAControls/XNATabControl.cs
@@ -42,13 +42,7 @@ namespace Rampastring.XNAUI.XNAControls
 
         public Color TextColor
         {
-            get
-            {
-                if (_textColor.HasValue)
-                    return _textColor.Value;
-
-                return UISettings.ActiveSettings.AltColor;
-            }
+            get => _textColor ?? UISettings.ActiveSettings.AltColor;
             set { _textColor = value; }
         }
 
@@ -56,13 +50,7 @@ namespace Rampastring.XNAUI.XNAControls
 
         public Color TextColorDisabled
         {
-            get
-            {
-                if (_textColorDisabled.HasValue)
-                    return _textColorDisabled.Value;
-
-                return UISettings.ActiveSettings.DisabledItemColor;
-            }
+            get => _textColorDisabled ?? UISettings.ActiveSettings.DisabledItemColor;
             set { _textColorDisabled = value; }
         }
 

--- a/XNAControls/XNATabControl.cs
+++ b/XNAControls/XNATabControl.cs
@@ -52,6 +52,20 @@ namespace Rampastring.XNAUI.XNAControls
             set { _textColor = value; }
         }
 
+        private Color? _textColorDisabled;
+
+        public Color TextColorDisabled
+        {
+            get
+            {
+                if (_textColorDisabled.HasValue)
+                    return _textColorDisabled.Value;
+
+                return UISettings.ActiveSettings.DisabledItemColor;
+            }
+            set { _textColorDisabled = value; }
+        }
+
         List<Tab> Tabs = new List<Tab>();
 
         public EnhancedSoundEffect ClickSound { get; set; }
@@ -109,11 +123,21 @@ namespace Rampastring.XNAUI.XNAControls
 
         protected override void ParseAttributeFromINI(IniFile iniFile, string key, string value)
         {
-            if (key.StartsWith("RemoveTabIndex"))
+
+            switch (key)
             {
-                int index = int.Parse(key.Substring(14));
-                if (Conversions.BooleanFromString(value, false))
-                    RemoveTab(index);
+                case "RemapColor":
+                case "TextColor":
+                    TextColor = AssetLoader.GetColorFromString(value);
+                    return;
+                case "TextColorDisabled":
+                    TextColorDisabled = AssetLoader.GetColorFromString(value);
+                    return;
+                case "RemoveTabIndex":
+                    int index = int.Parse(key.Substring(14));
+                    if (Conversions.BooleanFromString(value, false))
+                        RemoveTab(index);
+                    return;
             }
 
             base.ParseAttributeFromINI(iniFile, key, value);
@@ -161,7 +185,7 @@ namespace Rampastring.XNAUI.XNAControls
 
                 DrawStringWithShadow(tab.Text, FontIndex,
                     new Vector2(x + tab.TextXPosition, tab.TextYPosition),
-                    TextColor);
+                    tab.Selectable && Enabled ? TextColor : TextColorDisabled);
 
                 x += tab.DefaultTexture.Width;
             }

--- a/XNAControls/XNATabControl.cs
+++ b/XNAControls/XNATabControl.cs
@@ -123,7 +123,6 @@ namespace Rampastring.XNAUI.XNAControls
 
         protected override void ParseAttributeFromINI(IniFile iniFile, string key, string value)
         {
-
             switch (key)
             {
                 case "RemapColor":
@@ -133,11 +132,13 @@ namespace Rampastring.XNAUI.XNAControls
                 case "TextColorDisabled":
                     TextColorDisabled = AssetLoader.GetColorFromString(value);
                     return;
-                case "RemoveTabIndex":
-                    int index = int.Parse(key.Substring(14));
-                    if (Conversions.BooleanFromString(value, false))
-                        RemoveTab(index);
-                    return;
+            }
+
+            if (key.StartsWith("RemoveTabIndex"))
+            {
+                int index = int.Parse(key.Substring(14));
+                if (Conversions.BooleanFromString(value, false))
+                    RemoveTab(index);
             }
 
             base.ParseAttributeFromINI(iniFile, key, value);


### PR DESCRIPTION
Self-explanatory. Makes XNATabControl text appear with different color if control is disabled or tab is unselectable. This disabled text color is customizable and defaults to the same color used by disabled buttons by default.