### PR TITLE
Fixed texture blending for XNAButton & XNACheckBox

### DIFF
--- a/XNAControls/XNAButton.cs
+++ b/XNAControls/XNAButton.cs
@@ -295,7 +295,7 @@ namespace Rampastring.XNAUI.XNAControls
             {
                 if (IdleTextureAlpha > 0f)
                     DrawTexture(IdleTexture, new Rectangle(0, 0, Width, Height),
-                        RemapColor * Alpha);
+                        RemapColor * IdleTextureAlpha * Alpha);
 
                 if (HoverTexture != null && HoverTextureAlpha > 0f)
                     DrawTexture(HoverTexture, new Rectangle(0, 0, Width, Height),

--- a/XNAControls/XNACheckBox.cs
+++ b/XNAControls/XNACheckBox.cs
@@ -291,25 +291,25 @@ namespace Rampastring.XNAUI.XNAControls
             {
                 DrawTexture(clearTexture,
                     new Rectangle(0, checkBoxYPosition,
-                    clearTexture.Width, clearTexture.Height), Color.White);
+                    clearTexture.Width, clearTexture.Height), RemapColor);
             }
             else if (checkedAlpha == 1.0)
             {
                 DrawTexture(checkedTexture,
                     new Rectangle(0, checkBoxYPosition,
-                    clearTexture.Width, clearTexture.Height), 
-                    new Color(255, 255, 255, (int)(checkedAlpha * 255)));
+                    clearTexture.Width, clearTexture.Height),
+                    RemapColor * Convert.ToSingle(checkedAlpha));
             }
             else
             {
                 DrawTexture(clearTexture,
                     new Rectangle(0, checkBoxYPosition,
-                    clearTexture.Width, clearTexture.Height), Color.White);
+                    clearTexture.Width, clearTexture.Height), RemapColor);
 
                 DrawTexture(checkedTexture,
                     new Rectangle(0, checkBoxYPosition,
                     clearTexture.Width, clearTexture.Height),
-                    new Color(255, 255, 255, (int)(checkedAlpha * 255)));
+                    RemapColor * Convert.ToSingle(checkedAlpha));
             }
 
             base.Draw(gameTime);


### PR DESCRIPTION
Previously XNAButton didn't apply alpha fade to IdleTexture properly, causing a janky transition that was most noticeable with textures that had transparent backgrounds.

XNACheckBox also called DrawTexture with a color mask that caused the textures to become too bright during fade animation, this has now been amended. Also changed the hardcoded white color used as color mask to RemapColor to match all other controls.