### PR TITLE
Fix ListBox newline not accounted when breaking up lines

### DIFF
--- a/TextParseReturnValue.cs
+++ b/TextParseReturnValue.cs
@@ -40,7 +40,7 @@ namespace Rampastring.XNAUI
 
             string line = string.Empty;
             List<string> returnValue = new List<string>();
-            string[] wordArray = text.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries);
+            string[] wordArray = text.Split(new string[] { " ", Environment.NewLine }, StringSplitOptions.RemoveEmptyEntries);
 
             foreach (string word in wordArray)
             {


### PR DESCRIPTION
This fixes the case when there is a newline, for example, in chat message, which is not accounted when calculating the size of the message, which leads to it overlapping with other messages.