### PR TITLE
Fixed the problem that DropDown moves down when opening up

### DIFF
--- a/XNAControls/XNADropDown.cs
+++ b/XNAControls/XNADropDown.cs
@@ -330,14 +330,14 @@ namespace Rampastring.XNAUI.XNAControls
             if (!OpenUp)
             {
                 DropDownState = DropDownState.OPENED_DOWN;
+                Height = DropDownTexture.Height + 2 + ItemHeight * Items.Count;
             }
             else
             {
                 DropDownState = DropDownState.OPENED_UP;
                 Y -= 1 + ItemHeight * Items.Count;
+                Height = DropDownTexture.Height + 1 + ItemHeight * Items.Count;
             }
-
-            Height = DropDownTexture.Height + 2 + ItemHeight * Items.Count;
 
             Detach();
             hoveredIndex = -1;


### PR DESCRIPTION
Always move down when opening DropDown upwards

I have a [simple demo repo](//github.com/frg2089/Demo-Rampastring.XNAUI.XNADropDown) that reproduces this problem

![image](https://user-images.githubusercontent.com/42184238/139167195-f19a9fc5-b08a-4d0f-9320-580a2a9dab26.png)
![image](https://user-images.githubusercontent.com/42184238/139167239-33ba05d3-42b3-458a-8856-fbdbb9b03646.png)
