### PR TITLE
GameClosing fix

### DIFF
--- a/Rampastring.XNAUI.csproj
+++ b/Rampastring.XNAUI.csproj
@@ -146,9 +146,9 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Rampastring.Tools" Version="2.0.4" />
-    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.162-beta" PrivateAssets="All" />
+    <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.164-beta" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
     <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
-    <PackageReference Include="TextCopy" Version="6.2.0" />
+    <PackageReference Include="TextCopy" Version="6.2.1" />
   </ItemGroup>
 </Project>

--- a/WindowManager.cs
+++ b/WindowManager.cs
@@ -230,6 +230,9 @@ public class WindowManager : DrawableGameComponent
     public void CloseGame()
     {
 #if !WINFORMS
+        // When using UniversalGL both GameClosing and Game.Exiting trigger GameWindowManager_GameWindowClosing().
+        // To avoid executing shutdown code twice we unsubscribe here from Game.Exiting.
+        // The default double subscription needs to stay to handle the case of a forceful shutdown e.g. alt+F4.
         Game.Exiting -= GameWindowManager_GameWindowClosing;
 #endif
         GameClosing?.Invoke(this, EventArgs.Empty);

--- a/WindowManager.cs
+++ b/WindowManager.cs
@@ -229,6 +229,9 @@ public class WindowManager : DrawableGameComponent
     /// </summary>
     public void CloseGame()
     {
+#if !WINFORMS
+        Game.Exiting -= GameWindowManager_GameWindowClosing;
+#endif
         GameClosing?.Invoke(this, EventArgs.Empty);
         Game.Exit();
     }


### PR DESCRIPTION
Don't invoke GameClosing twice when UniversalGL calls WindowManager.CloseGame().
