### PR TITLE
gameForm could be null in WindowsGL build

### DIFF
--- a/PlatformSpecific/WindowsGameWindowManager.cs
+++ b/PlatformSpecific/WindowsGameWindowManager.cs
@@ -54,6 +54,10 @@ internal class WindowsGameWindowManager : IGameWindowManager
 
     private void GameForm_ClientSizeChanged(object sender, EventArgs e)
     {
+#if WINFORMS
+        if (gameForm == null)
+            return;
+#endif
         ClientSizeChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -63,6 +67,9 @@ internal class WindowsGameWindowManager : IGameWindowManager
     public void CenterOnScreen()
     {
 #if WINFORMS
+        if (gameForm == null) 
+            return;
+
         var screen = System.Windows.Forms.Screen.FromHandle(gameForm.Handle);
         int currentWidth = screen.Bounds.Width;
         int currentHeight = screen.Bounds.Height;
@@ -80,9 +87,6 @@ internal class WindowsGameWindowManager : IGameWindowManager
 #endif
 
 #if XNA
-        if (gameForm == null)
-            return;
-
         gameForm.DesktopLocation = new System.Drawing.Point(x, y);
 #else
         game.Window.Position = new Microsoft.Xna.Framework.Point(screenX + x, screenY + y);


### PR DESCRIPTION
which results in crash when starting xna-cncnet-client on WindowsGL builds

```cs
var screen = System.Windows.Forms.Screen.FromHandle(gameForm.Handle);
```

where `gameForm.Handle` triggers a null reference

```txt
06.02. 12:05:16.804    Initializing GameClass.
06.02. 12:05:17.057    InitGraphicsMode: 1280x720
06.02. 12:05:17.071    KABOOOOOOM!!! Info:
06.02. 12:05:17.071    Type: System.NullReferenceException
06.02. 12:05:17.071    Message: Object reference not set to an instance of an object.
06.02. 12:05:17.079    Source: Rampastring.XNAUI.WindowsGL
06.02. 12:05:17.079    TargetSite.Name: CenterOnScreen
06.02. 12:05:17.080    Stacktrace:    at Rampastring.XNAUI.PlatformSpecific.WindowsGameWindowManager.CenterOnScreen()
   at DTAClient.DXGUI.GameClass.SetGraphicsMode(WindowManager wm)
   at DTAClient.DXGUI.GameClass.Initialize()
   at Microsoft.Xna.Framework.Game.DoInitialize()
   at Microsoft.Xna.Framework.Game.Run(GameRunBehavior runBehavior)
   at DTAClient.Startup.Execute()
   at DTAClient.PreStartup.Initialize(StartupParams parameters)
06.02. 12:05:17.085    KABOOOOOOOM
```

This PR skips CentorOnScreen if `gameForm` is null

Also, `GameForm_ClientSizeChanged` might be triggered before gameForm is initialized (especially in full screen mode)