### PR TITLE
Target net8 with some cleanups

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@main
       with:
-        dotnet-version: '7.x.x'
+        dotnet-version: '8.x.x'
     - name: Install GitVersion
       uses: gittools/actions/gitversion/setup@main
       with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ permissions:
 jobs:
   publish:
     if: github.repository == 'Rampastring/Rampastring.XNAUI'
-    runs-on: windows-latest
+    runs-on: windows-2022
     steps:
     - name: Checkout
       uses: actions/checkout@main

--- a/Input/Cursor.cs
+++ b/Input/Cursor.cs
@@ -93,7 +93,7 @@ public class Cursor : DrawableGameComponent
     /// the cursor sprite is hidden, otherwise the cursor sprite remains visible.
     /// </summary>
     /// <param name="path">The path to the cursor (.cur) file.</param>
-#if !NETFRAMEWORK
+#if NET5_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows5.0")]
 #endif
     public void LoadNativeCursor(string path)

--- a/Input/KeyboardEventInput.cs
+++ b/Input/KeyboardEventInput.cs
@@ -43,7 +43,7 @@ namespace Rampastring.XNAUI.Input
         /// Initialize the TextInput with the given GameWindow.
         /// </summary>
         /// <param name="window">The XNA window to which text input should be linked.</param>
-#if !NETFRAMEWORK
+#if NET5_0_OR_GREATER
         [System.Runtime.Versioning.SupportedOSPlatform("windows5.1.2600")]
 #endif
         public static void Initialize(GameWindow window)

--- a/NativeMethods.cs
+++ b/NativeMethods.cs
@@ -46,7 +46,7 @@ namespace Windows.Win32
         /// </remarks>
         [DllImport("User32", ExactSpelling = true, EntryPoint = "SetWindowLongPtrW", SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-#if !NETFRAMEWORK
+#if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows5.0")]
 #endif
         internal static extern nint SetWindowLongPtr(winmdroot.Foundation.HWND hWnd, winmdroot.UI.WindowsAndMessaging.WINDOW_LONG_PTR_INDEX nIndex, nint dwNewLong);
@@ -69,7 +69,7 @@ namespace Windows.Win32
         /// </remarks>
         [DllImport("User32", ExactSpelling = true, EntryPoint = "SetWindowLongA", SetLastError = true)]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-#if !NETFRAMEWORK
+#if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows5.0")]
 #endif
         internal static extern int SetWindowLong(winmdroot.Foundation.HWND hWnd, winmdroot.UI.WindowsAndMessaging.WINDOW_LONG_PTR_INDEX nIndex, int dwNewLong);
@@ -103,7 +103,7 @@ namespace Windows.Win32
         /// </remarks>
         [DllImport("User32", ExactSpelling = true, EntryPoint = "CallWindowProcW")]
         [DefaultDllImportSearchPaths(DllImportSearchPath.System32)]
-#if !NETFRAMEWORK
+#if NET5_0_OR_GREATER
         [SupportedOSPlatform("windows5.0")]
 #endif
         internal static extern IntPtr CallWindowProc(UI.WindowsAndMessaging.WndProcDelegate lpPrevWndFunc, IntPtr hWnd, uint Msg, IntPtr wParam, IntPtr lParam);

--- a/PlatformSpecific/IGameWindowManager.cs
+++ b/PlatformSpecific/IGameWindowManager.cs
@@ -12,7 +12,7 @@ internal interface IGameWindowManager
     event EventHandler ClientSizeChanged;
 
     void AllowClosing();
-#if !NETFRAMEWORK
+#if NET5_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows5.1.2600")]
 #endif
     void FlashWindow();

--- a/PlatformSpecific/WindowsGameWindowManager.cs
+++ b/PlatformSpecific/WindowsGameWindowManager.cs
@@ -158,7 +158,7 @@ internal class WindowsGameWindowManager : IGameWindowManager
     /// <summary>
     /// Flashes the game window on the taskbar.
     /// </summary>
-#if !NETFRAMEWORK
+#if NET5_0_OR_GREATER
     [System.Runtime.Versioning.SupportedOSPlatform("windows5.1.2600")]
 #endif
     public void FlashWindow()

--- a/PlatformSpecific/WindowsGameWindowManager.cs
+++ b/PlatformSpecific/WindowsGameWindowManager.cs
@@ -54,6 +54,10 @@ internal class WindowsGameWindowManager : IGameWindowManager
 
     private void GameForm_ClientSizeChanged(object sender, EventArgs e)
     {
+#if WINFORMS
+        if (gameForm == null)
+            return;
+#endif
         ClientSizeChanged?.Invoke(this, EventArgs.Empty);
     }
 
@@ -63,6 +67,9 @@ internal class WindowsGameWindowManager : IGameWindowManager
     public void CenterOnScreen()
     {
 #if WINFORMS
+        if (gameForm == null) 
+            return;
+
         var screen = System.Windows.Forms.Screen.FromHandle(gameForm.Handle);
         int currentWidth = screen.Bounds.Width;
         int currentHeight = screen.Bounds.Height;
@@ -80,9 +87,6 @@ internal class WindowsGameWindowManager : IGameWindowManager
 #endif
 
 #if XNA
-        if (gameForm == null)
-            return;
-
         gameForm.DesktopLocation = new System.Drawing.Point(x, y);
 #else
         game.Window.Position = new Microsoft.Xna.Framework.Point(screenX + x, screenY + y);

--- a/Rampastring.XNAUI.csproj
+++ b/Rampastring.XNAUI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework Condition="'$(Configuration)' == 'UniversalGLDebug' Or '$(Configuration)' == 'UniversalGLRelease'">net7.0</TargetFramework>
-    <TargetFrameworks Condition="'$(Configuration)' != 'UniversalGLDebug' And '$(Configuration)' != 'UniversalGLRelease'">net7.0-windows;net48</TargetFrameworks>
+    <TargetFramework Condition="'$(Configuration)' == 'UniversalGLDebug' Or '$(Configuration)' == 'UniversalGLRelease'">net8.0</TargetFramework>
+    <TargetFrameworks Condition="'$(Configuration)' != 'UniversalGLDebug' And '$(Configuration)' != 'UniversalGLRelease'">net8.0-windows;net48</TargetFrameworks>
     <UseWindowsForms Condition="'$(Configuration)' != 'UniversalGLDebug' And '$(Configuration)' != 'UniversalGLRelease'">true</UseWindowsForms>
     <Title Condition="'$(Configuration)' == 'WindowsDXRelease'">Rampastring.XNAUI (WindowsDX)</Title>
     <Title Condition="'$(Configuration)' == 'WindowsGLRelease'">Rampastring.XNAUI (WindowsGL)</Title>

--- a/Rampastring.XNAUI.csproj
+++ b/Rampastring.XNAUI.csproj
@@ -148,7 +148,7 @@
     <PackageReference Include="Rampastring.Tools" Version="2.0.5" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.2.164-beta" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />
-    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.3" />
+    <PackageReference Include="SixLabors.ImageSharp" Version="2.1.6" />
     <PackageReference Include="TextCopy" Version="6.2.1" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Note: to reduce my burden on maintaining multiple branches, this PR contains the commit of PR https://github.com/Rampastring/Rampastring.XNAUI/pull/29 as a prerequisite.

This PR:
- Targets .NET 8 instead of .NET 7
- Fixes incorrect #if which causes compilation error for .NET Standard 2.0 (although not targeted)
- Update SixLabors.ImageSharp to 2.1.6 (from 2.1.3), which is the last version supporting .NET 4.8. Upgrading this minor version makes it easier to handle dependencies issues of xna-cncnet-client and brings no drawback.
