### PR TITLE
Add GIF support

### DIFF
--- a/Animation.cs
+++ b/Animation.cs
@@ -5,6 +5,7 @@ using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
 using SixLabors.ImageSharp;
 using Rampastring.Tools;
+using SixLabors.ImageSharp.Formats;
 
 namespace Rampastring.XNAUI;
 
@@ -25,36 +26,24 @@ public class Animation
     public int Height { get; private set; }
     public int Width { get; private set; }
 
-    public Animation(string value)
+    public Animation(Image image, IImageFormat format)
     {
-        FileInfo sourcePath = null;
-
-        foreach (string searchPath in AssetLoader.AssetSearchPaths)
+        switch(format.ToString())
         {
-            FileInfo fileInfo = SafePath.GetFile(searchPath, value);
-
-            if (fileInfo.Exists)
-            {
-                sourcePath = fileInfo;
-                break;
-            }
-        }
-
-        switch (sourcePath.Extension.ToLowerInvariant())
-        {
-            case ".gif":
-                FromGIF(value);
+            case "SixLabors.ImageSharp.Formats.Gif.GifFormat":
+                FromGIF(image);
                 break;
             default:
                 break;
         }
     }
 
-    private void FromGIF(string value)
+    public Animation(Image gif) => FromGIF(gif);
+
+    private void FromGIF(Image gif)
     {
         Frames = new List<Frame>();
         
-        var gif = AssetLoader.LoadGIFAnimation(value);
         currentDelay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
 
         Height = gif.Height;

--- a/Animation.cs
+++ b/Animation.cs
@@ -66,10 +66,13 @@ public class Animation
         {
             // ImageSharp returns not milliseconds, but decisecond
             var delay = gif.Frames[i].Metadata.GetGifMetadata().FrameDelay;
-            var currentFrame = gif.Frames.ExportFrame(0);
+
+            // When delay is equal to 1 or less, browsers use a delay equivalent to 100ms.
+            // Example: https://source.chromium.org/chromium/chromium/src/+/main:third_party/blink/renderer/platform/graphics/deferred_image_decoder.cc;drc=e15f3c2e15ee7570159406526444fa1ffb35150f;l=351
+            var currentDelay = delay > 1? delay * 10 : 100;
             var currentFrame = gif.Frames.CloneFrame(i);
 
-            Frames.Add(new AnimationFrame { Texture = AssetLoader.TextureFromImage(currentFrame), Delay = TimeSpan.FromMilliseconds(delay) });
+            Frames.Add(new AnimationFrame { Texture = AssetLoader.TextureFromImage(currentFrame), Delay = TimeSpan.FromMilliseconds(currentDelay) });
         }
 
         CurrentFrame = Frames[0].Texture;

--- a/Animation.cs
+++ b/Animation.cs
@@ -9,12 +9,18 @@ using System.IO;
 
 namespace Rampastring.XNAUI;
 
+/// <summary>
+/// Basic class of animation texture with delay.
+/// </summary>
 public class AnimationFrame
 {
     public Texture2D Texture { get; set; }
     public TimeSpan Delay { get; set; }
 }
 
+/// <summary>
+/// General purpose animation class.
+/// </summary>
 public class Animation
 {
     private List<AnimationFrame> Frames = null;
@@ -29,6 +35,10 @@ public class Animation
     public int Height { get; private set; }
     public int Width { get; private set; }
 
+    /// <summary>
+    /// Generic constructor.
+    /// </summary>
+    /// <param name="frames">List of frames.</param>
     public Animation(List<AnimationFrame> frames)
     {
         Frames = frames;
@@ -40,6 +50,12 @@ public class Animation
         }
     }
 
+    /// <summary>
+    /// Loads animation from ImageSharp format.
+    /// </summary>
+    /// <param name="image">The actual animation parsed by ImageSharp.</param>
+    /// <param name="format">The animation format details.</param>
+    /// <exception cref="NotSupportedException"></exception>
     public Animation(Image image, IImageFormat format)
     {
         this.image = image;
@@ -56,6 +72,10 @@ public class Animation
         }
     }
 
+    /// <summary>
+    /// Loads GIF format animation.
+    /// </summary>
+    /// <param name="gif">The actual animation parsed by ImageSharp.</param>
     public Animation(Image gif) => FromGIF(gif);
 
     private void FromGIF(Image gif)
@@ -87,6 +107,10 @@ public class Animation
         CurrentFrame = AssetLoader.TextureFromImage(gif.Frames.CloneFrame(0));
     }
 
+    /// <summary>
+    /// Draw next frame when frame delay expires.
+    /// </summary>
+    /// <param name="gameTime"></param>
     public void Update(GameTime gameTime)
     {
         totalElapsedTime += Convert.ToInt32(gameTime.ElapsedGameTime.TotalMilliseconds);
@@ -98,6 +122,9 @@ public class Animation
         }
     }
 
+    /// <summary>
+    /// Draw next frame of animation.
+    /// </summary>
     public void NextFrame()
     {
         if (repeatCount == 1 && currentFrameId == Frames.Count - 1)

--- a/Animation.cs
+++ b/Animation.cs
@@ -21,6 +21,7 @@ public class Animation
     private int currentFrameId = 0;
     private int currentDelay = 0;
     private int totalElapsedTime = 0;
+    private int repeatCount = 0;
 
     public Texture2D CurrentFrame { get; private set; }
     public int Height { get; private set; }
@@ -54,7 +55,8 @@ public class Animation
     private void FromGIF(Image gif)
     {
         Frames = new List<AnimationFrame>();
-        
+
+        repeatCount = gif.Metadata.GetGifMetadata().RepeatCount;
         currentDelay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
 
         Height = gif.Height;
@@ -91,6 +93,12 @@ public class Animation
 
     public void Update()
     {
+        if (repeatCount == 1 && currentFrameId == Frames.Count - 1)
+            return;
+
+        if (currentFrameId == Frames.Count - 1)
+            repeatCount -= 1;
+
         currentFrameId = (currentFrameId + 1) % Frames.Count;
         currentDelay = Frames[currentFrameId].Delay.Milliseconds;
         CurrentFrame = Frames[currentFrameId].Texture;

--- a/Animation.cs
+++ b/Animation.cs
@@ -9,7 +9,7 @@ using SixLabors.ImageSharp.Formats;
 
 namespace Rampastring.XNAUI;
 
-class Frame
+class AnimationFrame
 {
     public Texture2D Texture { get; set; }
     public TimeSpan Delay { get; set; }
@@ -17,7 +17,7 @@ class Frame
 
 public class Animation
 {
-    private List<Frame> Frames;
+    private List<AnimationFrame> Frames;
     private int currentFrameId = 0;
     private int currentDelay = 0;
     private int totalElapsedTime = 0;
@@ -42,7 +42,7 @@ public class Animation
 
     private void FromGIF(Image gif)
     {
-        Frames = new List<Frame>();
+        Frames = new List<AnimationFrame>();
         
         currentDelay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
 
@@ -58,7 +58,7 @@ public class Animation
             var delay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
             var currentFrame = gif.Frames.ExportFrame(0);
 
-            Frames.Add(new Frame { Texture = AssetLoader.TextureFromImage(currentFrame), Delay = TimeSpan.FromMilliseconds(delay) });
+            Frames.Add(new AnimationFrame { Texture = AssetLoader.TextureFromImage(currentFrame), Delay = TimeSpan.FromMilliseconds(delay) });
         }
 
         CurrentFrame = Frames[0].Texture;

--- a/Animation.cs
+++ b/Animation.cs
@@ -60,14 +60,14 @@ public class Animation
         Height = gif.Height;
         Width = gif.Width;
 
-        // ImageSharp doesn't return last gif frame
-        int len = gif.Frames.Count - 1;
+        int len = gif.Frames.Count;
 
         for (int i = 0; i < len; i++)
         {
             // ImageSharp returns not milliseconds, but decisecond
-            var delay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
+            var delay = gif.Frames[i].Metadata.GetGifMetadata().FrameDelay;
             var currentFrame = gif.Frames.ExportFrame(0);
+            var currentFrame = gif.Frames.CloneFrame(i);
 
             Frames.Add(new AnimationFrame { Texture = AssetLoader.TextureFromImage(currentFrame), Delay = TimeSpan.FromMilliseconds(delay) });
         }

--- a/Animation.cs
+++ b/Animation.cs
@@ -1,8 +1,10 @@
-﻿using Microsoft.Xna.Framework.Graphics;
-using SixLabors.ImageSharp;
 using System;
+using System.IO;
 using System.Collections.Generic;
 using Microsoft.Xna.Framework;
+using Microsoft.Xna.Framework.Graphics;
+using SixLabors.ImageSharp;
+using Rampastring.Tools;
 
 namespace Rampastring.XNAUI;
 
@@ -20,10 +22,35 @@ public class Animation
     private int totalElapsedTime = 0;
 
     public Texture2D CurrentFrame { get; private set; }
-    public int Height { get; }
-    public int Width { get; }
+    public int Height { get; private set; }
+    public int Width { get; private set; }
 
-    public Animation(string value) 
+    public Animation(string value)
+    {
+        FileInfo sourcePath = null;
+
+        foreach (string searchPath in AssetLoader.AssetSearchPaths)
+        {
+            FileInfo fileInfo = SafePath.GetFile(searchPath, value);
+
+            if (fileInfo.Exists)
+            {
+                sourcePath = fileInfo;
+                break;
+            }
+        }
+
+        switch (sourcePath.Extension.ToLowerInvariant())
+        {
+            case ".gif":
+                FromGIF(value);
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void FromGIF(string value)
     {
         Frames = new List<Frame>();
         

--- a/Animation.cs
+++ b/Animation.cs
@@ -147,8 +147,10 @@ public class Animation
         else
         {
             // Otherwise we have the source image and would be better off saving memory.
+            var clonedFrame = image.Frames.CloneFrame(currentFrameId);
             CurrentFrame.Dispose();
-            CurrentFrame = AssetLoader.TextureFromImage(image.Frames.CloneFrame(currentFrameId));
+            CurrentFrame = AssetLoader.TextureFromImage(clonedFrame);
+            clonedFrame.Dispose();
         }
     }
 }

--- a/Animation.cs
+++ b/Animation.cs
@@ -9,7 +9,7 @@ using System.IO;
 
 namespace Rampastring.XNAUI;
 
-class AnimationFrame
+public class AnimationFrame
 {
     public Texture2D Texture { get; set; }
     public TimeSpan Delay { get; set; }
@@ -25,6 +25,16 @@ public class Animation
     public Texture2D CurrentFrame { get; private set; }
     public int Height { get; private set; }
     public int Width { get; private set; }
+
+    public Animation(List<AnimationFrame> frames)
+    {
+        Frames = frames;
+        
+        if (Frames == null) return;
+        if (Frames.Count == 0) return;
+
+        currentDelay = (int)frames[0].Delay.TotalMilliseconds;
+    }
 
     public Animation(Image image, IImageFormat format)
     {

--- a/Animation.cs
+++ b/Animation.cs
@@ -31,10 +31,11 @@ public class Animation
     {
         Frames = frames;
         
-        if (Frames == null) return;
-        if (Frames.Count == 0) return;
-
-        currentDelay = (int)frames[0].Delay.TotalMilliseconds;
+        if (Frames != null && Frames.Count > 0)
+        {
+            CurrentFrame = frames[0].Texture;
+            currentDelay = (int)frames[0].Delay.TotalMilliseconds;
+        }
     }
 
     public Animation(Image image, IImageFormat format)

--- a/Animation.cs
+++ b/Animation.cs
@@ -90,6 +90,10 @@ public class Animation
 
         int len = gif.Frames.Count;
 
+        int estimatedSize = Height * Width * len * 4 / 1024 / 1024;
+        if (estimatedSize >= 50)
+            Logger.Log("Loading animation with estimated size more than 50MiB in raw format.");
+
         for (int i = 0; i < len; i++)
         {
             // ImageSharp returns not milliseconds, but decisecond as documentation says.

--- a/Animation.cs
+++ b/Animation.cs
@@ -63,7 +63,7 @@ public class Animation
 
     public Texture2D Next()
     {
-        currentFrameId = ++currentFrameId % Frames.Count;
+        currentFrameId = (currentFrameId + 1) % Frames.Count;
         currentDelay = Frames[currentFrameId].Delay.Milliseconds;
         CurrentFrame = Frames[currentFrameId].Texture;
         return CurrentFrame;

--- a/Animation.cs
+++ b/Animation.cs
@@ -38,12 +38,13 @@ public class Animation
 
     public Animation(Image image, IImageFormat format)
     {
-        switch(format.ToString())
+        switch(format)
         {
-            case "SixLabors.ImageSharp.Formats.Gif.GifFormat":
+            case SixLabors.ImageSharp.Formats.Gif.GifFormat:
                 FromGIF(image);
                 break;
             default:
+                throw new NotSupportedException("Unsupported image format for animation: " + format.Name);
                 break;
         }
     }

--- a/Animation.cs
+++ b/Animation.cs
@@ -88,11 +88,11 @@ public class Animation
         if (totalElapsedTime > currentDelay)
         {
             totalElapsedTime = 0;
-            Update();
+            NextFrame();
         }
     }
 
-    public void Update()
+    public void NextFrame()
     {
         if (repeatCount == 1 && currentFrameId == Frames.Count - 1)
             return;

--- a/Animation.cs
+++ b/Animation.cs
@@ -1,11 +1,11 @@
-using System;
-using System.IO;
-using System.Collections.Generic;
 using Microsoft.Xna.Framework;
 using Microsoft.Xna.Framework.Graphics;
-using SixLabors.ImageSharp;
 using Rampastring.Tools;
+using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace Rampastring.XNAUI;
 

--- a/Animation.cs
+++ b/Animation.cs
@@ -55,7 +55,6 @@ public class Animation
     /// </summary>
     /// <param name="image">The actual animation parsed by ImageSharp.</param>
     /// <param name="format">The animation format details.</param>
-    /// <exception cref="NotSupportedException"></exception>
     public Animation(Image image, IImageFormat format)
     {
         this.image = image;

--- a/Animation.cs
+++ b/Animation.cs
@@ -6,10 +6,15 @@ using Microsoft.Xna.Framework;
 
 namespace Rampastring.XNAUI;
 
+class Frame
+{
+    public Texture2D Texture { get; set; }
+    public int Delay { get; set; }
+}
+
 public class Animation
 {
-    private List<Texture2D> Frames;
-    private List<int> Delays;
+    private List<Frame> Frames;
     private int currentFrameId = 0;
     private int currentDelay = 0;
     private int totalElapsedTime = 0;
@@ -20,8 +25,7 @@ public class Animation
 
     public Animation(string value) 
     {
-        Frames = new List<Texture2D>();
-        Delays = new List<int>();
+        Frames = new List<Frame>();
         
         var gif = AssetLoader.LoadAnimation(value);
         currentDelay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
@@ -31,22 +35,21 @@ public class Animation
 
         try
         {
-            // ImageSharper have a bug that gives half of all frame count
+            // ImageSharp have a bug that gives half of all frame count
             for (;;)
             {
-                // ImageSharper returns not milliseconds, but decisecond
+                // ImageSharp returns not milliseconds, but decisecond
                 var delay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
                 var currentFrame = gif.Frames.ExportFrame(0);
 
-                Delays.Add(delay);
-                Frames.Add(AssetLoader.TextureFromImage(currentFrame));
+                Frames.Add(new Frame{Texture = AssetLoader.TextureFromImage(currentFrame), Delay = delay});
             }
         }
         catch
         {
         }
 
-        CurrentFrame = Frames[0];
+        CurrentFrame = Frames[0].Texture;
     }
 
     public Texture2D Next(GameTime gameTime)
@@ -64,9 +67,9 @@ public class Animation
 
     public Texture2D Next()
     {
-        currentFrameId = ++currentFrameId % Delays.Count;
-        currentDelay = Delays[currentFrameId];
-        CurrentFrame = Frames[currentFrameId];
+        currentFrameId = ++currentFrameId % Frames.Count;
+        currentDelay = Frames[currentFrameId].Delay;
+        CurrentFrame = Frames[currentFrameId].Texture;
         return CurrentFrame;
     }
 }

--- a/Animation.cs
+++ b/Animation.cs
@@ -103,7 +103,7 @@ public class Animation
             var currentDelay = delay > 1? delay * 10 : 100;
             var currentFrame = gif.Frames.CloneFrame(i);
 
-            // ImageSharp image class is not fast enough to draw images in the expected time.
+            // Fill Frames only with delays because ImageSharp image class is not fast enough when it gets frame metadata and cause play lag.
             Frames.Add(new AnimationFrame { Texture = null, Delay = TimeSpan.FromMilliseconds(currentDelay) });
         }
 

--- a/Animation.cs
+++ b/Animation.cs
@@ -1,0 +1,72 @@
+﻿using Microsoft.Xna.Framework.Graphics;
+using SixLabors.ImageSharp;
+using System;
+using System.Collections.Generic;
+using Microsoft.Xna.Framework;
+
+namespace Rampastring.XNAUI;
+
+public class Animation
+{
+    private List<Texture2D> Frames;
+    private List<int> Delays;
+    private int currentFrameId = 0;
+    private int currentDelay = 0;
+    private int totalElapsedTime = 0;
+
+    public Texture2D CurrentFrame { get; private set; }
+    public int Height { get; }
+    public int Width { get; }
+
+    public Animation(string value) 
+    {
+        Frames = new List<Texture2D>();
+        Delays = new List<int>();
+        
+        var gif = AssetLoader.LoadAnimation(value);
+        currentDelay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
+
+        Height = gif.Height;
+        Width = gif.Width;
+
+        try
+        {
+            // ImageSharper have a bug that gives half of all frame count
+            for (;;)
+            {
+                // ImageSharper returns not milliseconds, but decisecond
+                var delay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
+                var currentFrame = gif.Frames.ExportFrame(0);
+
+                Delays.Add(delay);
+                Frames.Add(AssetLoader.TextureFromImage(currentFrame));
+            }
+        }
+        catch
+        {
+        }
+
+        CurrentFrame = Frames[0];
+    }
+
+    public Texture2D Next(GameTime gameTime)
+    {
+        totalElapsedTime += Convert.ToInt32(gameTime.ElapsedGameTime.TotalMilliseconds);
+
+        if (totalElapsedTime > currentDelay)
+        {
+            totalElapsedTime = 0;
+            return Next();
+        }
+
+        return null;
+    }
+
+    public Texture2D Next()
+    {
+        currentFrameId = ++currentFrameId % Delays.Count;
+        currentDelay = Delays[currentFrameId];
+        CurrentFrame = Frames[currentFrameId];
+        return CurrentFrame;
+    }
+}

--- a/Animation.cs
+++ b/Animation.cs
@@ -27,7 +27,7 @@ public class Animation
     {
         Frames = new List<Frame>();
         
-        var gif = AssetLoader.LoadAnimation(value);
+        var gif = AssetLoader.LoadGIFAnimation(value);
         currentDelay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
 
         Height = gif.Height;

--- a/Animation.cs
+++ b/Animation.cs
@@ -33,20 +33,16 @@ public class Animation
         Height = gif.Height;
         Width = gif.Width;
 
-        try
-        {
-            // ImageSharp have a bug that gives half of all frame count
-            for (;;)
-            {
-                // ImageSharp returns not milliseconds, but decisecond
-                var delay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
-                var currentFrame = gif.Frames.ExportFrame(0);
+        // ImageSharp doesn't return last gif frame
+        int len = gif.Frames.Count - 1;
 
-                Frames.Add(new Frame{Texture = AssetLoader.TextureFromImage(currentFrame), Delay = delay});
-            }
-        }
-        catch
+        for (int i = 0; i < len; i++)
         {
+            // ImageSharp returns not milliseconds, but decisecond
+            var delay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
+            var currentFrame = gif.Frames.ExportFrame(0);
+
+            Frames.Add(new Frame { Texture = AssetLoader.TextureFromImage(currentFrame), Delay = delay });
         }
 
         CurrentFrame = Frames[0].Texture;

--- a/Animation.cs
+++ b/Animation.cs
@@ -9,7 +9,7 @@ namespace Rampastring.XNAUI;
 class Frame
 {
     public Texture2D Texture { get; set; }
-    public int Delay { get; set; }
+    public TimeSpan Delay { get; set; }
 }
 
 public class Animation
@@ -42,7 +42,7 @@ public class Animation
             var delay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
             var currentFrame = gif.Frames.ExportFrame(0);
 
-            Frames.Add(new Frame { Texture = AssetLoader.TextureFromImage(currentFrame), Delay = delay });
+            Frames.Add(new Frame { Texture = AssetLoader.TextureFromImage(currentFrame), Delay = TimeSpan.FromMilliseconds(delay) });
         }
 
         CurrentFrame = Frames[0].Texture;
@@ -64,7 +64,7 @@ public class Animation
     public Texture2D Next()
     {
         currentFrameId = ++currentFrameId % Frames.Count;
-        currentDelay = Frames[currentFrameId].Delay;
+        currentDelay = Frames[currentFrameId].Delay.Milliseconds;
         CurrentFrame = Frames[currentFrameId].Texture;
         return CurrentFrame;
     }

--- a/Animation.cs
+++ b/Animation.cs
@@ -75,24 +75,21 @@ public class Animation
         CurrentFrame = Frames[0].Texture;
     }
 
-    public Texture2D Next(GameTime gameTime)
+    public void Update(GameTime gameTime)
     {
         totalElapsedTime += Convert.ToInt32(gameTime.ElapsedGameTime.TotalMilliseconds);
 
         if (totalElapsedTime > currentDelay)
         {
             totalElapsedTime = 0;
-            return Next();
+            Update();
         }
-
-        return null;
     }
 
-    public Texture2D Next()
+    public void Update()
     {
         currentFrameId = (currentFrameId + 1) % Frames.Count;
         currentDelay = Frames[currentFrameId].Delay.Milliseconds;
         CurrentFrame = Frames[currentFrameId].Texture;
-        return CurrentFrame;
     }
 }

--- a/AssetLoader.cs
+++ b/AssetLoader.cs
@@ -17,7 +17,7 @@ namespace Rampastring.XNAUI;
 
 /// <summary>
 /// A static class that provides easy-to-use methods
-/// for loading and generating assets such as textures and sounds.
+/// for loading and generating assets such as textures, animations, sounds.
 /// </summary>
 public static class AssetLoader
 {
@@ -79,7 +79,7 @@ public static class AssetLoader
     }
 
     /// <summary>
-    /// Loads a GIF animation with the specific name. If the animation isn't found from any
+    /// Loads an animation with the specific name. If the animation isn't found from any
     /// asset search path, returns a dummy animation with 1 frame.
     /// </summary>
     /// <param name="name">The name of the animation.</param>

--- a/AssetLoader.cs
+++ b/AssetLoader.cs
@@ -79,7 +79,7 @@ public static class AssetLoader
     }
 
     /// <summary>
-    /// Loads an GIF animation with the specific name. If the animation isn't found from any
+    /// Loads a GIF animation with the specific name. If the animation isn't found from any
     /// asset search path, returns a dummy animation with 1 frame.
     /// </summary>
     /// <param name="name">The name of the animation.</param>

--- a/AssetLoader.cs
+++ b/AssetLoader.cs
@@ -166,7 +166,7 @@ public static class AssetLoader
         }
         catch (Exception ex)
         {
-            Logger.Log("AssetLoader.LoadTextureInternal: loading texture " + name + " failed! Message: " + ex.Message);
+            Logger.Log($"{nameof(AssetLoader)}.{nameof(LoadAnimationInternal)}: loading animation {name} failed! Message: {ex.Message}");
         }
 
         imageFormat = null;

--- a/AssetLoader.cs
+++ b/AssetLoader.cs
@@ -1,18 +1,16 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
+using System.Globalization;
+using System.Collections.Generic;
 using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Graphics;
-using Rampastring.Tools;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Media;
+using Color = Microsoft.Xna.Framework.Color;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.Formats.Png;
-using Color = Microsoft.Xna.Framework.Color;
-using System.Globalization;
-using SixLabors.ImageSharp.Formats.Gif;
-using SixLabors.ImageSharp.Advanced;
 using SixLabors.ImageSharp.PixelFormats;
+using Rampastring.Tools;
 
 namespace Rampastring.XNAUI;
 
@@ -89,13 +87,7 @@ public static class AssetLoader
     {
         Image cachedAnimation = null;
 
-        try
-        {
-            cachedAnimation = animationsCache[name];
-        }
-        catch(Exception ex)
-        {
-        }
+        animationsCache.TryGetValue(name, out cachedAnimation);
 
         if (cachedAnimation != null)
             return cachedAnimation;

--- a/AssetLoader.cs
+++ b/AssetLoader.cs
@@ -1,17 +1,17 @@
-﻿using System;
-using System.IO;
-using System.Globalization;
-using System.Collections.Generic;
-using Microsoft.Xna.Framework.Audio;
-using Microsoft.Xna.Framework.Graphics;
+﻿using Microsoft.Xna.Framework.Audio;
 using Microsoft.Xna.Framework.Content;
+using Microsoft.Xna.Framework.Graphics;
 using Microsoft.Xna.Framework.Media;
-using Color = Microsoft.Xna.Framework.Color;
+using Rampastring.Tools;
 using SixLabors.ImageSharp;
+using SixLabors.ImageSharp.Formats;
 using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
-using Rampastring.Tools;
-using SixLabors.ImageSharp.Formats;
+using System;
+using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using Color = Microsoft.Xna.Framework.Color;
 
 namespace Rampastring.XNAUI;
 

--- a/AssetLoader.cs
+++ b/AssetLoader.cs
@@ -80,12 +80,12 @@ public static class AssetLoader
     }
 
     /// <summary>
-    /// Loads a animation with the specific name. If the animation isn't found from any
+    /// Loads an GIF animation with the specific name. If the animation isn't found from any
     /// asset search path, returns a dummy animation with 1 frame.
     /// </summary>
     /// <param name="name">The name of the animation.</param>
     /// <returns>The animation if it was found and could be loaded, otherwise a dummy animation.</returns>
-    public static Image LoadAnimation(string name)
+    public static Image LoadGIFAnimation(string name)
     {
         Image cachedAnimation = null;
 

--- a/AssetLoader.cs
+++ b/AssetLoader.cs
@@ -141,7 +141,7 @@ public static class AssetLoader
         }
         catch (Exception ex)
         {
-            Logger.Log("AssetLoader.LoadTextureInternal: loading texture " + name + " failed! Message: " + ex.Message);
+            Logger.Log($"{nameof(AssetLoader)}.{nameof(LoadTextureInternal)}: loading texture {name} failed! Message: {ex.Message}");
         }
 
         return null;
@@ -259,7 +259,7 @@ public static class AssetLoader
         }
         catch (Exception ex)
         {
-            Logger.Log("AssetLoader.TextureFromImage: failed to create texture! Message: " + ex.Message);
+            Logger.Log($"{nameof(AssetLoader)}.{nameof(TextureFromImage)}: failed to create texture! Message: {ex.Message}");
             return null;
         }
     }
@@ -290,7 +290,7 @@ public static class AssetLoader
             }
         }
 
-        Logger.Log("AssetLoader.LoadSound: Sound not found! " + name);
+        Logger.Log($"{nameof(AssetLoader)}.{nameof(LoadSound)}: sound not found! {name}");
 
         return null;
     }
@@ -308,7 +308,7 @@ public static class AssetLoader
         }
         catch (Exception ex)
         {
-            Logger.Log("Loading song " + name + " failed! Message: " + ex.Message);
+            Logger.Log($"{nameof(AssetLoader)}.{nameof(LoadSong)}: loading song {name} failed! Message: {ex.Message}");
             return null;
         }
     }
@@ -326,7 +326,7 @@ public static class AssetLoader
         }
         catch (Exception ex)
         {
-            Logger.Log("Loading shader effect " + name + " failed! Message: " + ex.Message);
+            Logger.Log($"{nameof(AssetLoader)}.{nameof(LoadEffect)}: loading shader effect {name} failed! Message: {ex.Message}");
             return null;
         }
     }

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -30,7 +30,7 @@ public class XNAPanel : XNAControl
     protected int frameDelay = 0;
     public virtual Texture2D BackgroundTexture { get; set; }
 
-    public virtual List<Image> BackgroundAnimation { get; set; }
+    public virtual List<Texture2D> BackgroundAnimation { get; set; }
 
     private Color? _borderColor;
 
@@ -88,12 +88,12 @@ public class XNAPanel : XNAControl
                 BackgroundTexture = AssetLoader.LoadTexture(value);
                 return;
             case "BackgroundAnimation":
-                BackgroundAnimation = new List<Image>();
-                var gif = AssetLoader.LoadAnimation(value);
+                BackgroundAnimation = new List<Texture2D>();
+                var gif = AssetLoader.LoadAnimation(value);  
                 frameDelay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
                 
                 for (int i = 0; i < gif.Frames.Count; i++)
-                    BackgroundAnimation.Add(gif.Frames.ExportFrame(0));
+                    BackgroundAnimation.Add(AssetLoader.TextureFromImage(gif.Frames.ExportFrame(0)));
                 
                 return;
             case "SolidColorBackgroundTexture":
@@ -127,13 +127,7 @@ public class XNAPanel : XNAControl
         Alpha += AlphaRate * (float)(gameTime.ElapsedGameTime.TotalMilliseconds / 100.0);
 
         currentElapsedTime = Convert.ToInt32(gameTime.ElapsedGameTime.TotalMilliseconds);
-        UpdateBackgroundAnimationFrame();
-
-        base.Update(gameTime);
-    }
-
-    protected async void UpdateBackgroundAnimationFrame()
-    {
+        
         if (BackgroundAnimation != null)
         {
             totalElapsedTime += currentElapsedTime;
@@ -141,10 +135,11 @@ public class XNAPanel : XNAControl
             if (totalElapsedTime < frameDelay) return;
 
             totalElapsedTime = 0;
-            Image frame = BackgroundAnimation[currentFrameId++ % BackgroundAnimation.Count];
-            BackgroundTexture.Dispose();
-            BackgroundTexture = AssetLoader.TextureFromImage(frame);
+            Texture2D frame = BackgroundAnimation[currentFrameId++ % BackgroundAnimation.Count];
+            BackgroundTexture = frame;
         }
+
+        base.Update(gameTime);
     }
 
     protected void DrawBackgroundTexture(Texture2D texture, Color color)

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -24,13 +24,13 @@ public class XNAPanel : XNAControl
 
     public PanelBackgroundImageDrawMode PanelBackgroundDrawMode { get; set; } = PanelBackgroundImageDrawMode.STRETCHED;
 
-    protected int currentFrameId = 0;
-    protected int totalElapsedTime = 0;
-    protected int currentElapsedTime = 0;
-    protected int frameDelay = 0;
     public virtual Texture2D BackgroundTexture { get; set; }
 
     public virtual List<Texture2D> BackgroundAnimation { get; set; }
+
+    protected int currentFrameId = 0;
+    protected int totalElapsedTime = 0;
+    protected int frameDelay = 0;
 
     private Color? _borderColor;
 
@@ -89,11 +89,19 @@ public class XNAPanel : XNAControl
                 return;
             case "BackgroundAnimation":
                 BackgroundAnimation = new List<Texture2D>();
-                var gif = AssetLoader.LoadAnimation(value);  
+                var gif = AssetLoader.LoadAnimation(value);
                 frameDelay = gif.Frames[0].Metadata.GetGifMetadata().FrameDelay * 10;
-                
-                for (int i = 0; i < gif.Frames.Count; i++)
-                    BackgroundAnimation.Add(AssetLoader.TextureFromImage(gif.Frames.ExportFrame(0)));
+                Height = gif.Height;
+                Width = gif.Width;
+
+                try
+                {
+                    for (;;)
+                        BackgroundAnimation.Add(AssetLoader.TextureFromImage(gif.Frames.ExportFrame(0)));
+                }
+                catch
+                {
+                }
                 
                 return;
             case "SolidColorBackgroundTexture":
@@ -128,8 +136,7 @@ public class XNAPanel : XNAControl
 
         if (BackgroundAnimation != null)
         {
-
-            currentElapsedTime = Convert.ToInt32(gameTime.ElapsedGameTime.TotalMilliseconds);
+            int currentElapsedTime = Convert.ToInt32(gameTime.ElapsedGameTime.TotalMilliseconds);
             totalElapsedTime += currentElapsedTime;
 
             if (totalElapsedTime < frameDelay) return;

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -124,7 +124,10 @@ public class XNAPanel : XNAControl
         Alpha += AlphaRate * (float)(gameTime.ElapsedGameTime.TotalMilliseconds / 100.0);
 
         if (BackgroundAnimation != null)
-            BackgroundTexture = BackgroundAnimation.Next(gameTime) ?? BackgroundTexture;
+        {
+            BackgroundAnimation.Update(gameTime);
+            BackgroundTexture = BackgroundAnimation.CurrentFrame;
+        }
 
         base.Update(gameTime);
     }

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -2,17 +2,17 @@
 using Microsoft.Xna.Framework.Graphics;
 using Rampastring.Tools;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Png;
-using System.Globalization;
-using System.IO;
-using Color = Microsoft.Xna.Framework.Color;
-using Rectangle = Microsoft.Xna.Framework.Rectangle;
-using SixLabors.ImageSharp.Formats.Gif;
 using SixLabors.ImageSharp.Advanced;
+using SixLabors.ImageSharp.Formats.Gif;
+using SixLabors.ImageSharp.Formats.Png;
 using SixLabors.ImageSharp.PixelFormats;
-using System.Threading;
 using System;
 using System.Collections.Generic;
+using System.Globalization;
+using System.IO;
+using System.Threading;
+using Color = Microsoft.Xna.Framework.Color;
+using Rectangle = Microsoft.Xna.Framework.Rectangle;
 
 namespace Rampastring.XNAUI.XNAControls;
 

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -88,7 +88,8 @@ public class XNAPanel : XNAControl
                 BackgroundTexture = BackgroundAnimation.CurrentFrame;
                 return;
             case "ResizeControlUpToAnimationSize":
-                if (!Conversions.BooleanFromString(value, false) || BackgroundAnimation == null) return;
+                if (BackgroundAnimation == null || !Conversions.BooleanFromString(value, false))
+                    return;
                 Height = BackgroundAnimation.Height;
                 Width = BackgroundAnimation.Width;
                 return;

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -83,16 +83,16 @@ public class XNAPanel : XNAControl
             case "BackgroundTexture":
                 BackgroundTexture = AssetLoader.LoadTexture(value);
                 return;
-            case "BackgroundAnimation":
-                BackgroundAnimation = AssetLoader.LoadAnimation(value);
-                BackgroundTexture = BackgroundAnimation.CurrentFrame;
-                return;
-            case "ResizeControlUpToAnimationSize":
-                if (BackgroundAnimation == null || !Conversions.BooleanFromString(value, false))
-                    return;
-                Height = BackgroundAnimation.Height;
-                Width = BackgroundAnimation.Width;
-                return;
+            //case "BackgroundAnimation":
+            //    BackgroundAnimation = AssetLoader.LoadAnimation(value);
+            //    BackgroundTexture = BackgroundAnimation.CurrentFrame;
+            //    return;
+            //case "ResizeControlUpToAnimationSize":
+            //    if (BackgroundAnimation == null || !Conversions.BooleanFromString(value, false))
+            //        return;
+            //    Height = BackgroundAnimation.Height;
+            //    Width = BackgroundAnimation.Width;
+            //    return;
             case "SolidColorBackgroundTexture":
                 BackgroundTexture = AssetLoader.CreateTexture(AssetLoader.GetColorFromString(value), 2, 2);
                 PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
@@ -123,11 +123,11 @@ public class XNAPanel : XNAControl
     {
         Alpha += AlphaRate * (float)(gameTime.ElapsedGameTime.TotalMilliseconds / 100.0);
 
-        if (BackgroundAnimation != null)
-        {
-            BackgroundAnimation.Update(gameTime);
-            BackgroundTexture = BackgroundAnimation.CurrentFrame;
-        }
+        //if (BackgroundAnimation != null)
+        //{
+        //    BackgroundAnimation.Update(gameTime);
+        //    BackgroundTexture = BackgroundAnimation.CurrentFrame;
+        //}
 
         base.Update(gameTime);
     }

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -27,9 +27,6 @@ public class XNAPanel : XNAControl
     public virtual Texture2D BackgroundTexture { get; set; }
 
     public virtual Animation BackgroundAnimation { get; set; }
-    public virtual List<int> Delays { get; set; }
-
-    protected int totalElapsedTime = 0;
 
     private Color? _borderColor;
 

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -86,8 +86,11 @@ public class XNAPanel : XNAControl
             case "BackgroundAnimation":
                 BackgroundAnimation = new Animation(value);
                 BackgroundTexture = BackgroundAnimation.CurrentFrame;
+                return;
+            case "ResizeControlUpToAnimationSize":
+                if (!Conversions.BooleanFromString(value, false)) return;
                 Height = BackgroundAnimation.Height;
-                Width  = BackgroundAnimation.Width;
+                Width = BackgroundAnimation.Width;
                 return;
             case "SolidColorBackgroundTexture":
                 BackgroundTexture = AssetLoader.CreateTexture(AssetLoader.GetColorFromString(value), 2, 2);

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -83,16 +83,6 @@ public class XNAPanel : XNAControl
             case "BackgroundTexture":
                 BackgroundTexture = AssetLoader.LoadTexture(value);
                 return;
-            //case "BackgroundAnimation":
-            //    BackgroundAnimation = AssetLoader.LoadAnimation(value);
-            //    BackgroundTexture = BackgroundAnimation.CurrentFrame;
-            //    return;
-            //case "ResizeControlUpToAnimationSize":
-            //    if (BackgroundAnimation == null || !Conversions.BooleanFromString(value, false))
-            //        return;
-            //    Height = BackgroundAnimation.Height;
-            //    Width = BackgroundAnimation.Width;
-            //    return;
             case "SolidColorBackgroundTexture":
                 BackgroundTexture = AssetLoader.CreateTexture(AssetLoader.GetColorFromString(value), 2, 2);
                 PanelBackgroundDrawMode = PanelBackgroundImageDrawMode.STRETCHED;
@@ -122,12 +112,6 @@ public class XNAPanel : XNAControl
     public override void Update(GameTime gameTime)
     {
         Alpha += AlphaRate * (float)(gameTime.ElapsedGameTime.TotalMilliseconds / 100.0);
-
-        //if (BackgroundAnimation != null)
-        //{
-        //    BackgroundAnimation.Update(gameTime);
-        //    BackgroundTexture = BackgroundAnimation.CurrentFrame;
-        //}
 
         base.Update(gameTime);
     }

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -88,7 +88,7 @@ public class XNAPanel : XNAControl
                 BackgroundTexture = BackgroundAnimation.CurrentFrame;
                 return;
             case "ResizeControlUpToAnimationSize":
-                if (!Conversions.BooleanFromString(value, false)) return;
+                if (!Conversions.BooleanFromString(value, false) || BackgroundAnimation == null) return;
                 Height = BackgroundAnimation.Height;
                 Width = BackgroundAnimation.Width;
                 return;

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -84,7 +84,7 @@ public class XNAPanel : XNAControl
                 BackgroundTexture = AssetLoader.LoadTexture(value);
                 return;
             case "BackgroundAnimation":
-                BackgroundAnimation = new Animation(value);
+                BackgroundAnimation = AssetLoader.LoadAnimation(value);
                 BackgroundTexture = BackgroundAnimation.CurrentFrame;
                 return;
             case "ResizeControlUpToAnimationSize":

--- a/XNAControls/XNAPanel.cs
+++ b/XNAControls/XNAPanel.cs
@@ -126,17 +126,16 @@ public class XNAPanel : XNAControl
     {
         Alpha += AlphaRate * (float)(gameTime.ElapsedGameTime.TotalMilliseconds / 100.0);
 
-        currentElapsedTime = Convert.ToInt32(gameTime.ElapsedGameTime.TotalMilliseconds);
-        
         if (BackgroundAnimation != null)
         {
+
+            currentElapsedTime = Convert.ToInt32(gameTime.ElapsedGameTime.TotalMilliseconds);
             totalElapsedTime += currentElapsedTime;
 
             if (totalElapsedTime < frameDelay) return;
 
             totalElapsedTime = 0;
-            Texture2D frame = BackgroundAnimation[currentFrameId++ % BackgroundAnimation.Count];
-            BackgroundTexture = frame;
+            BackgroundTexture = BackgroundAnimation[currentFrameId++ % BackgroundAnimation.Count];
         }
 
         base.Update(gameTime);


### PR DESCRIPTION
PR implements support for the GIF image format for XNAPanel and its children (e.g. XNAWindowBase) using SixLabors.ImageSharper.

To enable animation, you need to set the `BackgroundAnimation` key with the name of the GIF file.

Example for `MainMenu.ini`:

```ini
[ExtraControls]
0=Logo:XNAExtraPanel
1=txtVersion:XNALabel
2=btnRankedMatch:XNALinkButton

[Logo]
Location=369,80
BackgroundTexture=lslogo.png
BackgroundAnimation=frog.gif
```

Demonstration:

https://github.com/user-attachments/assets/af0789c3-f59f-474b-aaba-e041d6c6b354

