### PR TITLE
Abstract more IME specific things

### DIFF
--- a/Input/IIMEHandler.cs
+++ b/Input/IIMEHandler.cs
@@ -13,17 +13,19 @@ public interface IIMEHandler
     /// </summary>
     bool Enabled { get; }
 
-    void RegisterXNATextBox(XNATextBox box, Action<char> handleCharInput);
+    void RegisterXNATextBox(XNATextBox sender, Action<char> handleCharInput);
 
-    void KillXNATextBox(XNATextBox box);
+    void KillXNATextBox(XNATextBox sender);
 
-    void OnXNATextBoxSelectedChanged(XNATextBox sender);
+    void OnSelectedChanged(XNATextBox sender);
 
-    bool ShouldIMEHandleCharacterInput(XNATextBox sender);
+    void OnCharacterInput(XNATextBox sender, out bool handled);
 
-    bool ShouldIMEHandleScrollKey(XNATextBox sender);
+    void OnScrollLeftKey(XNATextBox sender, out bool handled);
+    void OnScrollRightKey(XNATextBox sender, out bool handled);
 
-    bool ShouldIMEHandleBackspaceOrDeleteKey_WithSideEffect(XNATextBox sender);
+    void OnBackspaceKey(XNATextBox sender, out bool handled);
+    void OnDeleteKey(XNATextBox sender, out bool handled);
 
-    bool ShouldDrawCompositionText(XNATextBox sender, out string composition, out int compositionCursorPosition);
+    void OnDrawCompositionText(XNATextBox sender, out bool drawCompositionText, out string composition, out int compositionCursorPosition);
 }

--- a/Input/IIMEHandler.cs
+++ b/Input/IIMEHandler.cs
@@ -9,9 +9,9 @@ namespace Rampastring.XNAUI.Input;
 public interface IIMEHandler
 {
     /// <summary>
-    /// Determines whether the IME (not the IME handler) is enabled.
+    /// Determines whether IME is allowed to compose text.
     /// </summary>
-    bool Enabled { get; }
+    bool TextCompositionEnabled { get; }
 
     void RegisterXNATextBox(XNATextBox sender, Action<char> handleCharInput);
 

--- a/Input/IIMEHandler.cs
+++ b/Input/IIMEHandler.cs
@@ -19,7 +19,7 @@ public interface IIMEHandler
 
     void OnSelectedChanged(XNATextBox sender);
 
-    bool HandleCharacterInput(XNATextBox sender);
+    bool HandleCharInput(XNATextBox sender, char input);
 
     bool HandleScrollLeftKey(XNATextBox sender);
     bool HandleScrollRightKey(XNATextBox sender);

--- a/Input/IIMEHandler.cs
+++ b/Input/IIMEHandler.cs
@@ -4,46 +4,18 @@ using System;
 namespace Rampastring.XNAUI.Input;
 
 /// <summary>
-/// Event args for an event that contains a character.
-/// </summary>
-public class CharacterEventArgs : EventArgs
-{
-    public CharacterEventArgs(char character)
-    {
-        Character = character;
-    }
-    public char Character { get; }
-}
-
-/// <summary>
 /// Interface for outside components implementing Input Method Editor (IME) support.
 /// </summary>
 public interface IIMEHandler
 {
     /// <summary>
-    /// Gets or sets the control that is currently the focus of the IME.
-    /// </summary>
-    XNAControl IMEFocus { get; set; }
-
-    /// <summary>
-    /// Invoke when the IMM service emits characters.
-    /// </summary>
-    event EventHandler<CharacterEventArgs> CharInput;
-
-    /// <summary>
     /// Determines whether the IME (not the IME handler) is enabled.
     /// </summary>
     bool Enabled { get; }
 
-    /// <summary>
-    /// IME text composition string.
-    /// </summary>
-    string Composition { get; set; }
+    void RegisterXNATextBox(XNATextBox box, Action<char> handleCharInput);
 
-    /// <summary>
-    /// Caret position of the composition.
-    /// </summary>
-    int CompositionCursorPosition { get; set; }
+    void KillXNATextBox(XNATextBox box);
 
     void OnXNATextBoxSelectedChanged(XNATextBox sender);
 
@@ -53,4 +25,5 @@ public interface IIMEHandler
 
     bool ShouldIMEHandleBackspaceOrDeleteKey_WithSideEffect(XNATextBox sender);
 
+    bool ShouldDrawCompositionText(XNATextBox sender, out string composition, out int compositionCursorPosition);
 }

--- a/Input/IIMEHandler.cs
+++ b/Input/IIMEHandler.cs
@@ -26,6 +26,11 @@ public interface IIMEHandler
     XNAControl IMEFocus { get; set; }
 
     /// <summary>
+    /// Invoke when the IMM service emits characters.
+    /// </summary>
+    event EventHandler<CharacterEventArgs> CharInput;
+
+    /// <summary>
     /// Determines whether the IME (not the IME handler) is enabled.
     /// </summary>
     bool Enabled { get; }
@@ -39,11 +44,6 @@ public interface IIMEHandler
     /// Caret position of the composition.
     /// </summary>
     int CompositionCursorPosition { get; set; }
-
-    /// <summary>
-    /// Invoke when the IMM service emits characters.
-    /// </summary>
-    event EventHandler<CharacterEventArgs> CharInput;
 
     void OnXNATextBoxSelectedChanged(XNATextBox sender);
 

--- a/Input/IIMEHandler.cs
+++ b/Input/IIMEHandler.cs
@@ -1,5 +1,4 @@
-﻿using Microsoft.Xna.Framework;
-using Rampastring.XNAUI.XNAControls;
+﻿using Rampastring.XNAUI.XNAControls;
 using System;
 
 namespace Rampastring.XNAUI.Input;
@@ -13,20 +12,7 @@ public class CharacterEventArgs : EventArgs
     {
         Character = character;
     }
-
     public char Character { get; }
-}
-
-public class CompositionChangedEventArgs : EventArgs
-{
-    public CompositionChangedEventArgs(string oldValue, string newValue)
-    {
-        OldValue = oldValue;
-        NewValue = newValue;
-    }
-
-    public string OldValue { get; }
-    public string NewValue { get; }
 }
 
 /// <summary>
@@ -40,17 +26,7 @@ public interface IIMEHandler
     XNAControl IMEFocus { get; set; }
 
     /// <summary>
-    /// Invoke when the IMM service emits characters.
-    /// </summary>
-    event EventHandler<CharacterEventArgs> CharInput;
-
-    /// <summary>
-    /// Invoke when the text composition is changed.
-    /// </summary>
-    event EventHandler<CompositionChangedEventArgs> CompositionChanged;
-
-    /// <summary>
-    /// Determines whether the IME handler is enabled.
+    /// Determines whether the IME (not the IME handler) is enabled.
     /// </summary>
     bool Enabled { get; }
 
@@ -65,18 +41,16 @@ public interface IIMEHandler
     int CompositionCursorPosition { get; set; }
 
     /// <summary>
-    /// Enables the system IMM service to support composited character input.
-    /// Called when the library expects text input from a user and IME is enabled.
+    /// Invoke when the IMM service emits characters.
     /// </summary>
-    void StartTextComposition();
+    event EventHandler<CharacterEventArgs> CharInput;
 
-    /// <summary>
-    /// Stops the system IMM service.
-    /// </summary>
-    void StopTextComposition();
+    void OnXNATextBoxSelectedChanged(XNATextBox sender);
 
-    /// <summary>
-    /// Sets the rectangle used for typing Unicode text inputs with IME.
-    /// </summary>
-    void SetTextInputRectangle(Rectangle rectangle);
+    bool ShouldIMEHandleCharacterInput(XNATextBox sender);
+
+    bool ShouldIMEHandleScrollKey(XNATextBox sender);
+
+    bool ShouldIMEHandleBackspaceOrDeleteKey_WithSideEffect(XNATextBox sender);
+
 }

--- a/Input/IIMEHandler.cs
+++ b/Input/IIMEHandler.cs
@@ -18,6 +18,7 @@ public interface IIMEHandler
     void KillXNATextBox(XNATextBox sender);
 
     void OnSelectedChanged(XNATextBox sender);
+    void OnTextChanged(XNATextBox sender);
 
     bool HandleCharInput(XNATextBox sender, char input);
 

--- a/Input/IIMEHandler.cs
+++ b/Input/IIMEHandler.cs
@@ -19,13 +19,15 @@ public interface IIMEHandler
 
     void OnSelectedChanged(XNATextBox sender);
 
-    void OnCharacterInput(XNATextBox sender, out bool handled);
+    bool HandleCharacterInput(XNATextBox sender);
 
-    void OnScrollLeftKey(XNATextBox sender, out bool handled);
-    void OnScrollRightKey(XNATextBox sender, out bool handled);
+    bool HandleScrollLeftKey(XNATextBox sender);
+    bool HandleScrollRightKey(XNATextBox sender);
 
-    void OnBackspaceKey(XNATextBox sender, out bool handled);
-    void OnDeleteKey(XNATextBox sender, out bool handled);
+    bool HandleBackspaceKey(XNATextBox sender);
+    bool HandleDeleteKey(XNATextBox sender);
+    bool HandleEnterKey(XNATextBox sender);
+    bool HandleEscapeKey(XNATextBox sender);
 
-    void OnDrawCompositionText(XNATextBox sender, out bool drawCompositionText, out string composition, out int compositionCursorPosition);
+    bool GetDrawCompositionText(XNATextBox sender, out string composition, out int compositionCursorPosition);
 }

--- a/WindowManager.cs
+++ b/WindowManager.cs
@@ -150,9 +150,7 @@ public class WindowManager : DrawableGameComponent
     /// </summary>
     public bool IntegerScalingOnly { get; set; }
 
-    public IIMEHandler IMEHandler { get; set; }
-
-    public bool IsIMEEnabled => IMEHandler != null && IMEHandler.Enabled;
+    public IIMEHandler IMEHandler { get; set; } = null;
 
     private GraphicsDeviceManager graphics;
 

--- a/WindowManager.cs
+++ b/WindowManager.cs
@@ -793,7 +793,7 @@ public class WindowManager : DrawableGameComponent
 #if DEBUG
         Renderer.DrawString("Active control: " + activeControlName, 0, Vector2.Zero, Color.Red, 1.0f);
 
-        if (IMEHandler != null && IMEHandler.Enabled)
+        if (IMEHandler != null && IMEHandler.TextCompositionEnabled)
         {
             Renderer.DrawString("IME Enabled", 0, new Vector2(0, 16), Color.Red, 1.0f);
         }

--- a/XNAControls/XNATextBox.cs
+++ b/XNAControls/XNATextBox.cs
@@ -606,7 +606,8 @@ public class XNATextBox : XNAControl
 
     public override void OnSelectedChanged()
     {
-        WindowManager.IMEHandler.OnXNATextBoxSelectedChanged(this);
+        if (!IMEDisabled && WindowManager.IMEHandler != null)
+            WindowManager.IMEHandler.OnXNATextBoxSelectedChanged(this);
 
         base.OnSelectedChanged();
     }

--- a/XNAControls/XNATextBox.cs
+++ b/XNAControls/XNATextBox.cs
@@ -255,8 +255,7 @@ public class XNATextBox : XNAControl
     {
         if (!IMEDisabled && WindowManager.IMEHandler != null)
         {
-            WindowManager.IMEHandler.OnCharacterInput(this, out bool handled);
-            if (handled)
+            if (WindowManager.IMEHandler.HandleCharInput(this, e.Character))
                 return;
         }
 
@@ -267,8 +266,7 @@ public class XNATextBox : XNAControl
     {
         if (!IMEDisabled && WindowManager.IMEHandler != null)
         {
-            WindowManager.IMEHandler.OnCharacterInput(this, out bool handled);
-            if (handled)
+            if (WindowManager.IMEHandler.HandleCharInput(this, e.Character))
                 return;
         }
 

--- a/XNAControls/XNATextBox.cs
+++ b/XNAControls/XNATextBox.cs
@@ -226,14 +226,14 @@ public class XNATextBox : XNAControl
 
     private void InitializeIME()
     {
-        if (IMEDisabled || WindowManager.IMEHandler == null)
-            return;
+        if (!IMEDisabled && WindowManager.IMEHandler != null)
+            WindowManager.IMEHandler.RegisterXNATextBox(this, HandleCharInput);
+    }
 
-        WindowManager.IMEHandler.CharInput += (sender, e) =>
-        {
-            if (WindowManager.IMEHandler.IMEFocus == this)
-                HandleCharInput(e.Character);
-        };
+    private void DeinitializeIME()
+    {
+        if (!IMEDisabled && WindowManager.IMEHandler != null)
+            WindowManager.IMEHandler.KillXNATextBox(this);
     }
 
     public override void Kill()
@@ -244,6 +244,8 @@ public class XNATextBox : XNAControl
         KeyboardEventInput.CharEntered -= KeyboardEventInput_CharEntered;
 #endif
         Keyboard.OnKeyPressed -= Keyboard_OnKeyPressed;
+
+        DeinitializeIME();
 
         base.Kill();
     }
@@ -661,10 +663,10 @@ public class XNATextBox : XNAControl
 
             if (!IMEDisabled && WindowManager.IMEHandler != null)
             {
-                if (WindowManager.IMEHandler.IMEFocus == this && !string.IsNullOrEmpty(WindowManager.IMEHandler.Composition))
+                if (WindowManager.IMEHandler.ShouldDrawCompositionText(this, out string composition, out int compositionCursorPosition))
                 {
-                    DrawString(WindowManager.IMEHandler.Composition, FontIndex, new(barLocationX, TEXT_VERTICAL_MARGIN), Color.Orange);
-                    Vector2 measStr = Renderer.GetTextDimensions(WindowManager.IMEHandler.Composition.Substring(0, WindowManager.IMEHandler.CompositionCursorPosition), FontIndex);
+                    DrawString(composition, FontIndex, new(barLocationX, TEXT_VERTICAL_MARGIN), Color.Orange);
+                    Vector2 measStr = Renderer.GetTextDimensions(composition.Substring(0, compositionCursorPosition), FontIndex);
                     barLocationX += (int)measStr.X;
                 }
             }

--- a/XNAControls/XNATextBox.cs
+++ b/XNAControls/XNATextBox.cs
@@ -437,9 +437,21 @@ public class XNATextBox : XNAControl
 
                 return true;
             case Keys.Enter:
+                if (!IMEDisabled && WindowManager.IMEHandler != null)
+                {
+                    if (WindowManager.IMEHandler.HandleEnterKey(this))
+                        return true;
+                }
+
                 EnterPressed?.Invoke(this, EventArgs.Empty);
                 return true;
             case Keys.Escape:
+                if (!IMEDisabled && WindowManager.IMEHandler != null)
+                {
+                    if (WindowManager.IMEHandler.HandleEscapeKey(this))
+                        return true;
+                }
+
                 InputPosition = 0;
                 Text = string.Empty;
                 InputReceived?.Invoke(this, EventArgs.Empty);
@@ -536,8 +548,7 @@ public class XNATextBox : XNAControl
     {
         if (!IMEDisabled && WindowManager.IMEHandler != null)
         {
-            WindowManager.IMEHandler.OnScrollLeftKey(this, out bool handled);
-            if (handled)
+            if (WindowManager.IMEHandler.HandleScrollLeftKey(this))
                 return;
         }
 
@@ -559,8 +570,7 @@ public class XNATextBox : XNAControl
     {
         if (!IMEDisabled && WindowManager.IMEHandler != null)
         {
-            WindowManager.IMEHandler.OnScrollRightKey(this, out bool handled);
-            if (handled)
+            if (WindowManager.IMEHandler.HandleScrollRightKey(this))
                 return;
         }
 
@@ -584,8 +594,7 @@ public class XNATextBox : XNAControl
     {
         if (!IMEDisabled && WindowManager.IMEHandler != null)
         {
-            WindowManager.IMEHandler.OnDeleteKey(this, out bool handled);
-            if (handled)
+            if (WindowManager.IMEHandler.HandleDeleteKey(this))
                 return;
         }
 
@@ -609,8 +618,7 @@ public class XNATextBox : XNAControl
     {
         if (!IMEDisabled && WindowManager.IMEHandler != null)
         {
-            WindowManager.IMEHandler.OnBackspaceKey(this, out bool handled);
-            if (handled)
+            if (WindowManager.IMEHandler.HandleBackspaceKey(this))
                 return;
         }
 
@@ -688,8 +696,7 @@ public class XNATextBox : XNAControl
 
             if (!IMEDisabled && WindowManager.IMEHandler != null)
             {
-                WindowManager.IMEHandler.OnDrawCompositionText(this, out bool drawCompositionText, out string composition, out int compositionCursorPosition);
-                if (drawCompositionText)
+                if (WindowManager.IMEHandler.GetDrawCompositionText(this, out string composition, out int compositionCursorPosition))
                 {
                     DrawString(composition, FontIndex, new(barLocationX, TEXT_VERTICAL_MARGIN), Color.Orange);
                     Vector2 measStr = Renderer.GetTextDimensions(composition.Substring(0, compositionCursorPosition), FontIndex);

--- a/XNAControls/XNATextBox.cs
+++ b/XNAControls/XNATextBox.cs
@@ -227,7 +227,14 @@ public class XNATextBox : XNAControl
     private void InitializeIME()
     {
         if (!IMEDisabled && WindowManager.IMEHandler != null)
+        {
             WindowManager.IMEHandler.RegisterXNATextBox(this, HandleCharInput);
+
+            TextChanged += (sender, e) =>
+            {
+                WindowManager.IMEHandler.OnTextChanged(this);
+            };
+        }
     }
 
     private void DeinitializeIME()


### PR DESCRIPTION
After some tests, I found that commit 496e5aed34513e0dd7cdde84398909325bd26fab does not fully align with PR #32  (74399f9ab0ffe4f4a5c2cd83abe4a1d70edb1b0e). The following differs:
- `StartTextComposition()` is called when `XNATextBox.DisableIME is false && WindowManager.IMEHandler.Enabled is false` in 74399f9ab0ffe4f4a5c2cd83abe4a1d70edb1b0e. In 496e5aed34513e0dd7cdde84398909325bd26fab, `StartTextComposition()` is called when `XNATextBox.IMEDisabled is false && WindowManager.IsIMEEnabled is true` (note: the last true should be false). (found by @frg2089)
- initial value of `XNATextBox.textCompositionDelay`: true in 74399f9ab0ffe4f4a5c2cd83abe4a1d70edb1b0e, false in 496e5aed34513e0dd7cdde84398909325bd26fab 
- when `XNATextBox.textCompositionDelay is true && string.IsNullOrEmpty(WindowManager.IMEHandler.Composition)`, the early return in `DeleteCharacter()` and `Backspace()` is not triggered in 74399f9ab0ffe4f4a5c2cd83abe4a1d70edb1b0e, triggered in 496e5aed34513e0dd7cdde84398909325bd26fab 

The differences above stop IME from working as expected. However, instead of directly fixing them, I think it might be better to make the interface take care of these complex logics (e.g., returns whether DeleteCharacter() should have an early return for a specific XnaTextBox).

Links with https://github.com/CnCNet/xna-cncnet-client/pull/537
