### PR TITLE
Remove IME related codes in XNA KeyboardEventInput

### DIFF
--- a/Input/KeyboardEventInput.cs
+++ b/Input/KeyboardEventInput.cs
@@ -102,15 +102,15 @@ namespace Rampastring.XNAUI.Input
                     CharEntered?.Invoke(null, new KeyboardEventArgs((char)wParam.Value, (int)lParam.Value));
                     break;
 
-                case PInvoke.WM_IME_SETCONTEXT:
-                    if (wParam == 1)
-                        PInvoke.ImmAssociateContext(hWnd, hIMC);
-                    break;
+                // case PInvoke.WM_IME_SETCONTEXT:
+                //     if (wParam == 1)
+                //         PInvoke.ImmAssociateContext(hWnd, hIMC);
+                //     break;
 
-                case PInvoke.WM_INPUTLANGCHANGE:
-                    PInvoke.ImmAssociateContext(hWnd, hIMC);
-                    returnCode = (LRESULT)1;
-                    break;
+                // case PInvoke.WM_INPUTLANGCHANGE:
+                //     PInvoke.ImmAssociateContext(hWnd, hIMC);
+                //     returnCode = (LRESULT)1;
+                //     break;
             }
 
             return returnCode;

--- a/Input/KeyboardEventInput.cs
+++ b/Input/KeyboardEventInput.cs
@@ -37,7 +37,8 @@ namespace Rampastring.XNAUI.Input
         private static bool initialized;
         private static IntPtr prevWndProc;
         private static WNDPROC hookProcDelegate;
-        private static HIMC hIMC;
+
+        // private static HIMC hIMC;
 
         /// <summary>
         /// Initialize the TextInput with the given GameWindow.
@@ -72,7 +73,8 @@ namespace Rampastring.XNAUI.Input
                 prevWndProc = result;
             }
 
-            hIMC = PInvoke.ImmGetContext((HWND)window.Handle);
+            // hIMC = PInvoke.ImmGetContext((HWND)window.Handle);
+
             initialized = true;
         }
 


### PR DESCRIPTION
`WM_IME_SETCONTEXT` and `WM_INPUTLANGCHANGE` seems to be introduced in the very beginning. 

https://github.com/Rampastring/Rampastring.XNAUI/commit/eddc8dfcae2c2bbbbb892f70b312eddb0bac5be8#diff-31f9bf77e76cc0d506a3133412e4b4e6a70eb43f2d07e786f1d3dcc31242841cR106-R114

Without IME support, these codes should have never been executed before. Now, with IME enabled, it turns out an infinite recursion will occur when handling these two messages. Commenting out these lines work.

![图片](https://github.com/user-attachments/assets/0a366d64-c2db-4bf3-8a9a-d4993ab24929)


![c6a740351ce6ba34bfe3f7dd365fbc38](https://github.com/user-attachments/assets/cec09576-d6db-4bed-abc9-c84518ce1ae2)
