### PR TITLE
Fix additem slowness by keeping running count of visible lines

### DIFF
--- a/XNAControls/XNAListBox.cs
+++ b/XNAControls/XNAListBox.cs
@@ -121,7 +121,7 @@ public class XNAListBox : XNAPanel
         {
             if (value != _viewTop)
             {
-                if (_viewTop < 0)
+                if (value < 0)
                     _viewTop = 0;
                 else
                     _viewTop = value;

--- a/XNAControls/XNAListBox.cs
+++ b/XNAControls/XNAListBox.cs
@@ -302,7 +302,7 @@ public class XNAListBox : XNAPanel
     private TimeSpan timeSinceLastScroll = TimeSpan.Zero;
     private bool isScrollingQuickly = false;
     private bool selectedIndexChanged = false;
-    private int visibleLinesCount = 0;
+    private int visibleLineCount = 0;
 
     protected override void ParseControlINIAttribute(IniFile iniFile, string key, string value)
     {
@@ -337,7 +337,7 @@ public class XNAListBox : XNAPanel
         }
 
         Items.Clear();
-        visibleLinesCount = 0;
+        visibleLineCount = 0;
 
         RefreshScrollbar();
     }
@@ -394,7 +394,7 @@ public class XNAListBox : XNAPanel
 
         if (listBoxItem.Visible)
         {
-            visibleLinesCount += listBoxItem.TextLines.Count;
+            visibleLineCount += listBoxItem.TextLines.Count;
         }
 
         RefreshScrollbar();
@@ -412,8 +412,8 @@ public class XNAListBox : XNAPanel
 
         if (item.Visible)
         {
-            visibleLinesCount -= oldLineCount;
-            visibleLinesCount += item.TextLines.Count;
+            visibleLineCount -= oldLineCount;
+            visibleLineCount += item.TextLines.Count;
         }
 
         RefreshScrollbar();
@@ -424,11 +424,11 @@ public class XNAListBox : XNAPanel
         var item = (XNAListBoxItem)sender;
         if (item.Visible)
         {
-            visibleLinesCount += item.TextLines.Count;
+            visibleLineCount += item.TextLines.Count;
         }
         else
         {
-            visibleLinesCount -= item.TextLines.Count;
+            visibleLineCount -= item.TextLines.Count;
         }
 
         RefreshScrollbar();
@@ -487,7 +487,7 @@ public class XNAListBox : XNAPanel
 
         if (item.Visible)
         {
-            visibleLinesCount -= item.TextLines.Count;
+            visibleLineCount -= item.TextLines.Count;
         }
 
         item.TextChanged -= ListBoxItem_TextChanged;
@@ -547,7 +547,7 @@ public class XNAListBox : XNAPanel
     /// </summary>
     private int GetTotalLineCount()
     {
-        return visibleLinesCount;
+        return visibleLineCount;
     }
 
     /// <summary>

--- a/XNAControls/XNAListBoxItem.cs
+++ b/XNAControls/XNAListBoxItem.cs
@@ -21,6 +21,7 @@ public class XNAListBoxItem
     }
 
     public event EventHandler TextChanged;
+    public event EventHandler VisibilityChanged;
 
     private Color? _textColor;
 
@@ -97,7 +98,19 @@ public class XNAListBoxItem
     /// Whether this list box item is visible.
     /// Invisible list box items are not drawn and cannot be selected.
     /// </summary>
-    public bool Visible { get; set; } = true;
+    private bool visible = true;
+    public bool Visible
+    {
+        get { return visible; }
+        set
+        {
+            if (visible != value)
+            {
+                visible = value;
+                VisibilityChanged?.Invoke(this, EventArgs.Empty);
+            }
+        }
+    }
 
     public List<string> TextLines;
 }

--- a/XNAControls/XNAListBoxItem.cs
+++ b/XNAControls/XNAListBoxItem.cs
@@ -98,15 +98,15 @@ public class XNAListBoxItem
     /// Whether this list box item is visible.
     /// Invisible list box items are not drawn and cannot be selected.
     /// </summary>
-    private bool visible = true;
+    private bool _visible = true;
     public bool Visible
     {
-        get { return visible; }
+        get { return _visible; }
         set
         {
-            if (visible != value)
+            if (_visible != value)
             {
-                visible = value;
+                _visible = value;
                 VisibilityChanged?.Invoke(this, EventArgs.Empty);
             }
         }


### PR DESCRIPTION
This PR makes a change to keep a running count of how many visible lines there are rather than looping through the list to count them.

Note: With this change, you should no longer add/remove from the Items collection directly.
xna-cncnet-client will need this line updated:
https://github.com/CnCNet/xna-cncnet-client/blob/47834cabfa67da8378ffbec6b8b72aeebc4e3ee7/DXMainClient/DXGUI/Multiplayer/GameListBox.cs#L103

simply change to `Clear()"`

---

Also fixes an incorrect viewTop value.