### PR TITLE
Add ttf fonts

### DIFF
--- a/Rampastring.XNAUI.csproj
+++ b/Rampastring.XNAUI.csproj
@@ -144,6 +144,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <PackageReference Include="FontStashSharp.MonoGame" Version="1.3.10" />
     <PackageReference Include="Rampastring.Tools" Version="2.0.6" />
     <PackageReference Include="Microsoft.Windows.CsWin32" Version="0.3.49-beta" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" PrivateAssets="All" />

--- a/Renderer.cs
+++ b/Renderer.cs
@@ -13,551 +13,551 @@ using System.Reflection;
 #endif
 
 namespace Rampastring.XNAUI;
-    public struct SpriteBatchSettings
+public struct SpriteBatchSettings
+{
+    public SpriteBatchSettings(SpriteSortMode ssm, BlendState bs, SamplerState ss, DepthStencilState dss, RasterizerState rs, Effect effect)
     {
-        public SpriteBatchSettings(SpriteSortMode ssm, BlendState bs, SamplerState ss, DepthStencilState dss, RasterizerState rs, Effect effect)
-        {
-            SpriteSortMode = ssm;
-            BlendState = bs;
-            SamplerState = ss;
-            DepthStencilState = dss;
-            RasterizerState = rs;
-            Effect = effect;
-        }
-
-        public readonly SpriteSortMode SpriteSortMode;
-        public readonly SamplerState SamplerState;
-        public readonly BlendState BlendState;
-        public readonly DepthStencilState DepthStencilState;
-        public readonly RasterizerState RasterizerState;
-        public readonly Effect Effect;
+        SpriteSortMode = ssm;
+        BlendState = bs;
+        SamplerState = ss;
+        DepthStencilState = dss;
+        RasterizerState = rs;
+        Effect = effect;
     }
 
-    public abstract class IFont
+    public readonly SpriteSortMode SpriteSortMode;
+    public readonly SamplerState SamplerState;
+    public readonly BlendState BlendState;
+    public readonly DepthStencilState DepthStencilState;
+    public readonly RasterizerState RasterizerState;
+    public readonly Effect Effect;
+}
+
+public abstract class IFont
+{
+    public abstract Vector2 MeasureString(string text);
+    public abstract void DrawString(SpriteBatch spriteBatch, string text, Vector2 location, Color color, float scale, float depth);
+    public abstract void DrawString(SpriteBatch spriteBatch, StringSegment text, Vector2 location, Color color, float rotation, Vector2 origin, Vector2 scale, float depth);
+    public abstract bool HasCharacter(char c);
+    public abstract string GetSafeString(string str);
+}
+
+/// <summary>
+/// A wrapper for the classic XNA SpriteFont.
+/// </summary>
+public class SpriteFontWrapper : IFont
+{
+    internal readonly SpriteFont _font;
+
+    public SpriteFontWrapper(SpriteFont font)
     {
-        public abstract Vector2 MeasureString(string text);
-        public abstract void DrawString(SpriteBatch spriteBatch, string text, Vector2 location, Color color, float scale, float depth);
-        public abstract void DrawString(SpriteBatch spriteBatch, StringSegment text, Vector2 location, Color color, float rotation, Vector2 origin, Vector2 scale, float depth);
-        public abstract bool HasCharacter(char c);
-        public abstract string GetSafeString(string str);
+        _font = font;
     }
 
-    /// <summary>
-    /// A wrapper for the classic XNA SpriteFont.
-    /// </summary>
-    public class SpriteFontWrapper : IFont
+    public override Vector2 MeasureString(string text) => _font.MeasureString(text);
+
+    public override void DrawString(SpriteBatch spriteBatch, string text, Vector2 location, Color color, float scale, float depth) =>
+        spriteBatch.DrawString(_font, text, location, color, 0f, Vector2.Zero, scale, SpriteEffects.None, depth);
+
+    public override void DrawString(SpriteBatch spriteBatch, StringSegment text, Vector2 location, Color color, float rotation, Vector2 origin, Vector2 scale, float depth) =>
+        spriteBatch.DrawString(_font, text.ToString(), location, color, rotation, origin, scale.X, SpriteEffects.None, depth);
+
+    public override bool HasCharacter(char c) => _font.Characters.Contains(c);
+
+    public override string GetSafeString(string str)
     {
-        internal readonly SpriteFont _font;
-
-        public SpriteFontWrapper(SpriteFont font)
+        var sb = new StringBuilder(str);
+        for (int i = 0; i < str.Length; i++)
         {
-            _font = font;
-        }
-
-        public override Vector2 MeasureString(string text) => _font.MeasureString(text);
-
-        public override void DrawString(SpriteBatch spriteBatch, string text, Vector2 location, Color color, float scale, float depth) =>
-            spriteBatch.DrawString(_font, text, location, color, 0f, Vector2.Zero, scale, SpriteEffects.None, depth);
-
-        public override void DrawString(SpriteBatch spriteBatch, StringSegment text, Vector2 location, Color color, float rotation, Vector2 origin, Vector2 scale, float depth) =>
-            spriteBatch.DrawString(_font, text.ToString(), location, color, rotation, origin, scale.X, SpriteEffects.None, depth);
-
-        public override bool HasCharacter(char c) => _font.Characters.Contains(c);
-
-        public override string GetSafeString(string str)
-        {
-            var sb = new StringBuilder(str);
-            for (int i = 0; i < str.Length; i++)
+            char c = str[i];
+            if (c != '\r' && c != '\n' && !HasCharacter(c))
             {
-                char c = str[i];
-                if (c != '\r' && c != '\n' && !HasCharacter(c))
-                {
-                    sb.Replace(c, '?');
-                }
-            }
-            return sb.ToString();
-        }
-    }
-
-    /// <summary>
-    /// A wrapper for the FontStashSharp TTF fonts.
-    /// </summary>
-    public class TTFFontWrapper : IFont
-    {
-        internal readonly SpriteFontBase _font;
-
-        public TTFFontWrapper(SpriteFontBase font)
-        {
-            _font = font;
-        }
-
-        public override Vector2 MeasureString(string text)
-        {
-            var bounds = _font.MeasureString(text);
-            return new Vector2(bounds.X, bounds.Y);
-        }
-
-        public override void DrawString(SpriteBatch spriteBatch, string text, Vector2 location, Color color, float scale, float depth)
-        {
-            var vectorScale = new Vector2(scale, scale);
-            var segment = new StringSegment(text);
-            spriteBatch.DrawString(_font, segment, location, color, 0f, Vector2.Zero, vectorScale, depth);
-        }
-
-        public override void DrawString(SpriteBatch spriteBatch, StringSegment text, Vector2 location, Color color, float rotation, Vector2 origin, Vector2 scale, float depth) =>
-            spriteBatch.DrawString(_font, text, location, color, rotation, origin, scale, depth);
-
-        public override bool HasCharacter(char c) => true;
-
-        public override string GetSafeString(string str)
-        {
-            var sb = new StringBuilder(str);
-            for (int i = 0; i < str.Length; i++)
-            {
-                char c = str[i];
-                if (!char.IsControl(c) || c == '\r' || c == '\n')
-                {
-                    continue;
-                }
                 sb.Replace(c, '?');
             }
-            return sb.ToString();
         }
+        return sb.ToString();
+    }
+}
+
+/// <summary>
+/// A wrapper for the FontStashSharp TTF fonts.
+/// </summary>
+public class TTFFontWrapper : IFont
+{
+    internal readonly SpriteFontBase _font;
+
+    public TTFFontWrapper(SpriteFontBase font)
+    {
+        _font = font;
     }
 
-    public static class Renderer
+    public override Vector2 MeasureString(string text)
     {
-        private static SpriteBatch spriteBatch;
-        private static List<IFont> fonts;
-        private static FontSystem fontSystem;
+        var bounds = _font.MeasureString(text);
+        return new Vector2(bounds.X, bounds.Y);
+    }
 
-        private static Texture2D whitePixelTexture;
+    public override void DrawString(SpriteBatch spriteBatch, string text, Vector2 location, Color color, float scale, float depth)
+    {
+        var vectorScale = new Vector2(scale, scale);
+        var segment = new StringSegment(text);
+        spriteBatch.DrawString(_font, segment, location, color, 0f, Vector2.Zero, vectorScale, depth);
+    }
 
-        private static readonly LinkedList<SpriteBatchSettings> settingStack = new LinkedList<SpriteBatchSettings>();
+    public override void DrawString(SpriteBatch spriteBatch, StringSegment text, Vector2 location, Color color, float rotation, Vector2 origin, Vector2 scale, float depth) =>
+        spriteBatch.DrawString(_font, text, location, color, rotation, origin, scale, depth);
 
-        internal static SpriteBatchSettings CurrentSettings;
+    public override bool HasCharacter(char c) => true;
 
-        public static SpriteBatchSettings GetCurrentSettings() => CurrentSettings;
-
-        public static void Initialize(GraphicsDevice gd, ContentManager content)
+    public override string GetSafeString(string str)
+    {
+        var sb = new StringBuilder(str);
+        for (int i = 0; i < str.Length; i++)
         {
-            spriteBatch = new SpriteBatch(gd);
-            fonts = new List<IFont>();
-            LoadFonts(content);
-
-            whitePixelTexture = AssetLoader.CreateTexture(Color.White, 1, 1);
+            char c = str[i];
+            if (!char.IsControl(c) || c == '\r' || c == '\n')
+            {
+                continue;
+            }
+            sb.Replace(c, '?');
         }
+        return sb.ToString();
+    }
+}
 
-        /// <summary>
-        /// Clears all potentially existing loaded fonts and then loads fonts from asset loader directories.
-        /// </summary>
-        /// <param name="contentManager">A XNA/MonoGame ContentManager instance.</param>
-        public static void LoadFonts(ContentManager contentManager)
-        {
-            if (fonts == null)
-                fonts = new List<IFont>();
-            else
-                fonts.Clear();
+public static class Renderer
+{
+    private static SpriteBatch spriteBatch;
+    private static List<IFont> fonts;
+    private static FontSystem fontSystem;
 
-            fontSystem = new FontSystem();
-            string originalContentRoot = contentManager.RootDirectory;
+    private static Texture2D whitePixelTexture;
+
+    private static readonly LinkedList<SpriteBatchSettings> settingStack = new LinkedList<SpriteBatchSettings>();
+
+    internal static SpriteBatchSettings CurrentSettings;
+
+    public static SpriteBatchSettings GetCurrentSettings() => CurrentSettings;
+
+    public static void Initialize(GraphicsDevice gd, ContentManager content)
+    {
+        spriteBatch = new SpriteBatch(gd);
+        fonts = new List<IFont>();
+        LoadFonts(content);
+
+        whitePixelTexture = AssetLoader.CreateTexture(Color.White, 1, 1);
+    }
+
+    /// <summary>
+    /// Clears all potentially existing loaded fonts and then loads fonts from asset loader directories.
+    /// </summary>
+    /// <param name="contentManager">A XNA/MonoGame ContentManager instance.</param>
+    public static void LoadFonts(ContentManager contentManager)
+    {
+        if (fonts == null)
+            fonts = new List<IFont>();
+        else
+            fonts.Clear();
+
+        fontSystem = new FontSystem();
+        string originalContentRoot = contentManager.RootDirectory;
 #if XNA
-    var contentManagerType = contentManager.GetType();
-    var rootDirectoryField = contentManagerType.GetField("rootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
-    var fullRootDirectoryField = contentManager.GetType().GetField("fullRootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
+var contentManagerType = contentManager.GetType();
+var rootDirectoryField = contentManagerType.GetField("rootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
+var fullRootDirectoryField = contentManager.GetType().GetField("fullRootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
 #endif
 
-            foreach (string searchPath in AssetLoader.AssetSearchPaths)
+        foreach (string searchPath in AssetLoader.AssetSearchPaths)
+        {
+            string baseDir = SafePath.GetDirectory(searchPath).FullName;
+            string iniPath = Path.Combine(baseDir, "Fonts.ini");
+
+            if (File.Exists(iniPath))
             {
-                string baseDir = SafePath.GetDirectory(searchPath).FullName;
-                string iniPath = Path.Combine(baseDir, "Fonts.ini");
+                var iniFile = new IniFile(iniPath);
+                int fontCount = iniFile.GetIntValue("Fonts", "Count", 0);
 
-                if (File.Exists(iniPath))
+                for (int i = 0; i < fontCount; i++)
                 {
-                    var iniFile = new IniFile(iniPath);
-                    int fontCount = iniFile.GetIntValue("Fonts", "Count", 0);
+                    string section = $"Font{i}";
+                    string fontType = iniFile.GetStringValue(section, "Type", "SpriteFont");
+                    string fontPath = iniFile.GetStringValue(section, "Path", "");
+                    int size = iniFile.GetIntValue(section, "Size", 16);
 
-                    for (int i = 0; i < fontCount; i++)
+                    if (string.Equals(fontType, "TrueType", StringComparison.OrdinalIgnoreCase))
                     {
-                        string section = $"Font{i}";
-                        string fontType = iniFile.GetStringValue(section, "Type", "SpriteFont");
-                        string fontPath = iniFile.GetStringValue(section, "Path", "");
-                        int size = iniFile.GetIntValue(section, "Size", 16);
-
-                        if (string.Equals(fontType, "TrueType", StringComparison.OrdinalIgnoreCase))
+                        string fullFontPath = SafePath.GetFile(searchPath, fontPath).FullName;
+                        if (File.Exists(fullFontPath))
                         {
-                            string fullFontPath = SafePath.GetFile(searchPath, fontPath).FullName;
-                            if (File.Exists(fullFontPath))
-                            {
-                                fontSystem.AddFont(File.ReadAllBytes(fullFontPath));
-                                fonts.Add(new TTFFontWrapper(fontSystem.GetFont(size)));
-                            }
-                            else
-                                Logger.Log($"TTF font file not found: {fullFontPath}");
+                            fontSystem.AddFont(File.ReadAllBytes(fullFontPath));
+                            fonts.Add(new TTFFontWrapper(fontSystem.GetFont(size)));
                         }
                         else
-                        {
-                            string newRootDirectory = baseDir;
-#if !XNA
-                            contentManager.RootDirectory = newRootDirectory;
-#else
-                    rootDirectoryField.SetValue(contentManager, newRootDirectory);
-                    fullRootDirectoryField.SetValue(contentManager, newRootDirectory);
-#endif
-                            string sfName = Path.GetFileNameWithoutExtension(fontPath);
-                            if (SafePath.GetFile(searchPath, $"{sfName}.xnb").Exists)
-                            {
-                                fonts.Add(new SpriteFontWrapper(contentManager.Load<SpriteFont>(sfName)));
-                                Logger.Log($"Loaded SpriteFont: {sfName}");
-                            }
-                            else
-                            {
-                                Logger.Log($"SpriteFont file not found: {sfName}.xnb");
-                            }
-                        }
+                            Logger.Log($"TTF font file not found: {fullFontPath}");
                     }
-                }
-                else
-                {
-                    string newRootDirectory = baseDir;
-                    while (true)
+                    else
                     {
-                        string sfName = string.Format(CultureInfo.InvariantCulture, "SpriteFont{0}", fonts.Count);
-
-                        if (!SafePath.GetFile(searchPath, FormattableString.Invariant($"{sfName}.xnb")).Exists)
-                            break;
-
+                        string newRootDirectory = baseDir;
 #if !XNA
                         contentManager.RootDirectory = newRootDirectory;
 #else
-                // XNA does not allow changing the value of RootDirectory after the
-                // content manager has been used. However, it has some internal fields
-                // we can modify through reflection to achieve the same.
-
-                // This would be a very bad solution when using a library that
-                // is updated regularly, but since XNA has been EOL for over a decade
-                // by this point, its internal logic is never going to change.
-
                 rootDirectoryField.SetValue(contentManager, newRootDirectory);
                 fullRootDirectoryField.SetValue(contentManager, newRootDirectory);
 #endif
-
-                        fonts.Add(new SpriteFontWrapper(contentManager.Load<SpriteFont>(sfName)));
+                        string sfName = Path.GetFileNameWithoutExtension(fontPath);
+                        if (SafePath.GetFile(searchPath, $"{sfName}.xnb").Exists)
+                        {
+                            fonts.Add(new SpriteFontWrapper(contentManager.Load<SpriteFont>(sfName)));
+                            Logger.Log($"Loaded SpriteFont: {sfName}");
+                        }
+                        else
+                        {
+                            Logger.Log($"SpriteFont file not found: {sfName}.xnb");
+                        }
                     }
                 }
             }
+            else
+            {
+                string newRootDirectory = baseDir;
+                while (true)
+                {
+                    string sfName = string.Format(CultureInfo.InvariantCulture, "SpriteFont{0}", fonts.Count);
+
+                    if (!SafePath.GetFile(searchPath, FormattableString.Invariant($"{sfName}.xnb")).Exists)
+                        break;
 
 #if !XNA
-            contentManager.RootDirectory = originalContentRoot;
+                    contentManager.RootDirectory = newRootDirectory;
 #else
-    rootDirectoryField.SetValue(contentManager, originalContentRoot);
-    fullRootDirectoryField.SetValue(contentManager, originalContentRoot);
+            // XNA does not allow changing the value of RootDirectory after the
+            // content manager has been used. However, it has some internal fields
+            // we can modify through reflection to achieve the same.
+
+            // This would be a very bad solution when using a library that
+            // is updated regularly, but since XNA has been EOL for over a decade
+            // by this point, its internal logic is never going to change.
+
+            rootDirectoryField.SetValue(contentManager, newRootDirectory);
+            fullRootDirectoryField.SetValue(contentManager, newRootDirectory);
 #endif
-        }
 
-
-        /// <summary>
-        /// Allows direct access to the list of loaded fonts.
-        /// </summary>
-        public static List<IFont> GetFontList() => fonts;
-
-        /// <summary>
-        /// Returns a version of the given string where all characters that don't
-        /// appear in the given font have been replaced with question marks.
-        /// </summary>
-        /// <param name="str">The string.</param>
-        /// <param name="fontIndex">The index of the font.</param>
-        public static string GetSafeString(string str, int fontIndex)
-        {
-            if (fontIndex < 0 || fontIndex >= fonts.Count)
-                throw new IndexOutOfRangeException("Invalid font index.");
-
-            return fonts[fontIndex].GetSafeString(str);
-        }
-
-        /// <summary>
-        /// Returns a that has had its width limited to a specific number.
-        /// Characters that'd cross over the width have been cut.
-        /// </summary>
-        /// <param name="str">The string to limit.</param>
-        /// <param name="fontIndex">The index of the font to use.</param>
-        /// <param name="maxWidth">The maximum width of the string.</param>
-        /// <returns></returns>
-        public static string GetStringWithLimitedWidth(string str, int fontIndex, int maxWidth)
-        {
-            if (fontIndex < 0 || fontIndex >= fonts.Count)
-                throw new IndexOutOfRangeException("Invalid font index.");
-
-            var font = fonts[fontIndex];
-            var sb = new StringBuilder(str);
-            while (font.MeasureString(sb.ToString()).X > maxWidth && sb.Length > 0)
-            {
-                sb.Remove(sb.Length - 1, 1);
+                    fonts.Add(new SpriteFontWrapper(contentManager.Load<SpriteFont>(sfName)));
+                }
             }
-            return sb.ToString();
         }
 
-    public static TextParseReturnValue FixText(string text, int fontIndex, int width)
-    {
-        if (fontIndex < 0 || fontIndex >= fonts.Count)
-            throw new IndexOutOfRangeException("Invalid font index.");
-
-        IFont font = fonts[fontIndex];
-        return TextParseReturnValue.FixText(font, width, text);
+#if !XNA
+        contentManager.RootDirectory = originalContentRoot;
+#else
+rootDirectoryField.SetValue(contentManager, originalContentRoot);
+fullRootDirectoryField.SetValue(contentManager, originalContentRoot);
+#endif
     }
 
-    public static List<string> GetFixedTextLines(string text, int fontIndex, int width, bool splitWords = true, bool keepBlankLines = false)
+
+    /// <summary>
+    /// Allows direct access to the list of loaded fonts.
+    /// </summary>
+    public static List<IFont> GetFontList() => fonts;
+
+    /// <summary>
+    /// Returns a version of the given string where all characters that don't
+    /// appear in the given font have been replaced with question marks.
+    /// </summary>
+    /// <param name="str">The string.</param>
+    /// <param name="fontIndex">The index of the font.</param>
+    public static string GetSafeString(string str, int fontIndex)
     {
         if (fontIndex < 0 || fontIndex >= fonts.Count)
             throw new IndexOutOfRangeException("Invalid font index.");
 
-        IFont font = fonts[fontIndex];
-        return TextParseReturnValue.GetFixedTextLines(font, width, text, splitWords, keepBlankLines);
+        return fonts[fontIndex].GetSafeString(str);
     }
 
     /// <summary>
-    /// Pushes new settings into the renderer's internal stack and applies them.
-    /// A call to <see cref="PushSettings(SpriteBatchSettings)"/> should always
-    /// be followed by <see cref="PopSettings"/> once drawing with the new settings is done.
+    /// Returns a that has had its width limited to a specific number.
+    /// Characters that'd cross over the width have been cut.
+    /// </summary>
+    /// <param name="str">The string to limit.</param>
+    /// <param name="fontIndex">The index of the font to use.</param>
+    /// <param name="maxWidth">The maximum width of the string.</param>
+    /// <returns></returns>
+    public static string GetStringWithLimitedWidth(string str, int fontIndex, int maxWidth)
+    {
+        if (fontIndex < 0 || fontIndex >= fonts.Count)
+            throw new IndexOutOfRangeException("Invalid font index.");
+
+        var font = fonts[fontIndex];
+        var sb = new StringBuilder(str);
+        while (font.MeasureString(sb.ToString()).X > maxWidth && sb.Length > 0)
+        {
+            sb.Remove(sb.Length - 1, 1);
+        }
+        return sb.ToString();
+    }
+
+public static TextParseReturnValue FixText(string text, int fontIndex, int width)
+{
+    if (fontIndex < 0 || fontIndex >= fonts.Count)
+        throw new IndexOutOfRangeException("Invalid font index.");
+
+    IFont font = fonts[fontIndex];
+    return TextParseReturnValue.FixText(font, width, text);
+}
+
+public static List<string> GetFixedTextLines(string text, int fontIndex, int width, bool splitWords = true, bool keepBlankLines = false)
+{
+    if (fontIndex < 0 || fontIndex >= fonts.Count)
+        throw new IndexOutOfRangeException("Invalid font index.");
+
+    IFont font = fonts[fontIndex];
+    return TextParseReturnValue.GetFixedTextLines(font, width, text, splitWords, keepBlankLines);
+}
+
+/// <summary>
+/// Pushes new settings into the renderer's internal stack and applies them.
+/// A call to <see cref="PushSettings(SpriteBatchSettings)"/> should always
+/// be followed by <see cref="PopSettings"/> once drawing with the new settings is done.
+/// </summary>
+/// <param name="settings">The sprite batch settings.</param>
+public static void PushSettings(SpriteBatchSettings settings)
+    {
+        EndDraw();
+        PushSettingsInternal();
+        CurrentSettings = settings;
+        BeginDrawInternal(CurrentSettings);
+    }
+
+    /// <summary>
+    /// Pops previous settings from the renderer's internal stack and applies them.
+    /// </summary>
+    public static void PopSettings()
+    {
+        EndDraw();
+        PopSettingsInternal();
+        BeginDrawInternal(CurrentSettings);
+    }
+
+    /// <summary>
+    /// Changes current rendering settings. This can be called between 
+    /// <see cref="PushSettings(SpriteBatchSettings)"/> and <see cref="PopSettings"/>
+    /// when you want to draw something with new settings, but there's no reason 
+    /// to save those settings.
     /// </summary>
     /// <param name="settings">The sprite batch settings.</param>
-    public static void PushSettings(SpriteBatchSettings settings)
-        {
-            EndDraw();
-            PushSettingsInternal();
-            CurrentSettings = settings;
-            BeginDrawInternal(CurrentSettings);
-        }
-
-        /// <summary>
-        /// Pops previous settings from the renderer's internal stack and applies them.
-        /// </summary>
-        public static void PopSettings()
-        {
-            EndDraw();
-            PopSettingsInternal();
-            BeginDrawInternal(CurrentSettings);
-        }
-
-        /// <summary>
-        /// Changes current rendering settings. This can be called between 
-        /// <see cref="PushSettings(SpriteBatchSettings)"/> and <see cref="PopSettings"/>
-        /// when you want to draw something with new settings, but there's no reason 
-        /// to save those settings.
-        /// </summary>
-        /// <param name="settings">The sprite batch settings.</param>
-        public static void ChangeSettings(SpriteBatchSettings settings)
-        {
-            EndDraw();
-            CurrentSettings = settings;
-            BeginDrawInternal(CurrentSettings);
-        }
-
-        /// <summary>
-        /// Prepares the renderer for drawing a batch of sprites.
-        /// </summary>
-        public static void BeginDraw()
-        {
-            BeginDrawInternal(CurrentSettings);
-        }
-
-        /// <summary>
-        /// Draws the currently queued batch of sprites.
-        /// </summary>
-        public static void EndDraw()
-        {
-            spriteBatch.End();
-        }
-
-        public static void PushRenderTarget(RenderTarget2D renderTarget) => RenderTargetStack.PushRenderTarget(renderTarget,
-            new SpriteBatchSettings(SpriteSortMode.Deferred, BlendState.AlphaBlend, null, null, null, null));
-
-        public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2) =>
-            RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2);
-
-        public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2, RenderTarget2D renderTarget3) =>
-            RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2, renderTarget3);
-
-        public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2, RenderTarget2D renderTarget3, RenderTarget2D renderTarget4) =>
-            RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2, renderTarget3, renderTarget4);
-
-        public static void PushRenderTarget(RenderTarget2D renderTarget, SpriteBatchSettings settings) => RenderTargetStack.PushRenderTarget(renderTarget, settings);
-
-        public static void PopRenderTarget() => RenderTargetStack.PopRenderTarget();
-
-        //BlendState blendState = new BlendState();
-        //blendState.AlphaDestinationBlend = Blend.One;
-        //blendState.ColorDestinationBlend = Blend.InverseSourceAlpha;
-        //blendState.AlphaSourceBlend = Blend.SourceAlpha;
-        //blendState.ColorSourceBlend = Blend.SourceAlpha;
-
-        internal static void BeginDrawInternal(SpriteBatchSettings settings) =>
-            BeginDrawInternal(settings.SpriteSortMode, settings.BlendState, settings.SamplerState, settings.DepthStencilState, settings.RasterizerState, settings.Effect);
-
-        internal static void BeginDrawInternal(SpriteSortMode ssm, BlendState bs, SamplerState ss, DepthStencilState dss, RasterizerState rs, Effect effect)
-        {
-#if XNA
-            spriteBatch.Begin(ssm, bs, ss, DepthStencilState.Default, RasterizerState.CullNone);
-#else
-            spriteBatch.Begin(ssm, bs, ss, dss, rs, effect);
-#endif
-        }
-
-        internal static void PushSettingsInternal()
-        {
-            settingStack.AddFirst(CurrentSettings);
-        }
-
-        internal static void PopSettingsInternal()
-        {
-            CurrentSettings = settingStack.First.Value;
-            settingStack.RemoveFirst();
-        }
-
-        internal static void ClearStack()
-        {
-            settingStack.Clear();
-        }
-
-        #region Rendering code
-
-        public static void DrawTexture(Texture2D texture, Rectangle rectangle, Color color)
-        {
-            spriteBatch.Draw(texture, rectangle, color);
-        }
-
-        public static void DrawTexture(Texture2D texture, Rectangle sourceRectangle, Rectangle destinationRectangle, Color color)
-        {
-            spriteBatch.Draw(texture, destinationRectangle, sourceRectangle, color);
-        }
-
-        public static void DrawTexture(Texture2D texture, Rectangle sourceRectangle, Vector2 location, float rotation, Vector2 origin, Vector2 scale, Color color, float layerDepth = 0f)
-        {
-            spriteBatch.Draw(texture, location, sourceRectangle, color, rotation, origin, scale, SpriteEffects.None, layerDepth);
-        }
-
-        public static void DrawTexture(Texture2D texture, Rectangle destinationRectangle, Rectangle? sourceRectangle, Color color, float rotation, Vector2 origin, SpriteEffects effects, float layerDepth)
-        {
-            spriteBatch.Draw(texture, destinationRectangle, sourceRectangle, color, rotation, origin, effects, layerDepth);
-        }
-
-        public static void DrawTexture(Texture2D texture, Vector2 location, float rotation, Vector2 origin, Vector2 scale, Color color, float layerDepth = 0f)
-        {
-            spriteBatch.Draw(texture, location, null, color, rotation, origin, scale, SpriteEffects.None, layerDepth);
-        }
-
-        /// <summary>
-        /// Draws a circle's perimiter.
-        /// </summary>
-        /// <param name="position">The center point of the circle.</param>
-        /// <param name="radius">The radius of the circle.</param>
-        /// <param name="color">The color of the circle.</param>
-        /// <param name="precision">Defines how smooth the circle's perimiter is. 
-        /// Larger values make the circle smoother, but have a larger effect on performance.</param>
-        /// <param name="thickness">The thickness of the perimiter.</param>
-        public static void DrawCircle(Vector2 position, float radius, Color color, int precision = 8, int thickness = 1)
-        {
-            float angle = 0f;
-            float increase = (float)Math.PI * 2f / precision;
-
-            Vector2 point = position + RMath.VectorFromLengthAndAngle(radius, angle);
-
-            for (int i = 0; i <= precision; i++)
-            {
-                Vector2 nextPoint = position + RMath.VectorFromLengthAndAngle(radius, angle);
-                DrawLine(point, nextPoint, color, thickness);
-                point = nextPoint;
-                angle += increase;
-            }
-        }
-
-        /// <summary>
-        /// Draws a circle where the circle's perimeter is dotted with a texture.
-        /// </summary>
-        /// <param name="position">The center point of the circle.</param>
-        /// <param name="radius">The radius of the circle.</param>
-        /// <param name="texture">The texture to dot the circle's perimiter with.</param>
-        /// <param name="color">The remap color of the texture.</param>
-        /// <param name="precision">How many times the texture is drawn on the perimiter.</param>
-        /// <param name="scale">The scale of the drawn texture compared to the size of the texture itself.</param>
-        /// <param name="layerDepth">The depth of the texture.</param>
-        public static void DrawCircleWithTexture(Vector2 position, float radius,
-            Texture2D texture, Color color, int precision = 8, float scale = 1f, float layerDepth = 0f)
-        {
-            float angle = 0f;
-            float increase = (float)Math.PI * 2f / precision;
-
-            Vector2 point = position + RMath.VectorFromLengthAndAngle(radius, angle);
-
-            for (int i = 0; i <= precision; i++)
-            {
-                DrawTexture(texture, point, 0f,
-                    new Vector2(texture.Width / 2f, texture.Height / 2f),
-                    new Vector2(scale, scale), color, layerDepth);
-                point = position + RMath.VectorFromLengthAndAngle(radius, angle);
-                angle += increase;
-            }
-        }
-
-        public static void DrawString(string text, int fontIndex, Vector2 location, Color color, float scale = 1.0f, float depth = 0f)
-        {
-            if (fontIndex < 0 || fontIndex >= fonts.Count)
-                throw new IndexOutOfRangeException("Invalid font index: " + fontIndex);
-
-            fonts[fontIndex].DrawString(spriteBatch, text, location, color, scale, depth);
-        }
-
-        public static void DrawStringWithShadow(string text, int fontIndex, Vector2 location, Color color, float scale = 1.0f, float shadowDistance = 1.0f, float depth = 0f)
-        {
-            if (fontIndex < 0 || fontIndex >= fonts.Count)
-                throw new IndexOutOfRangeException("Invalid font index: " + fontIndex);
-
-            Color shadowColor;
-#if XNA
-            shadowColor = new Color(0, 0, 0, color.A);
-#else
-            shadowColor = UISettings.ActiveSettings.TextShadowColor * (color.A / 255.0f);
-#endif
-
-            fonts[fontIndex].DrawString(spriteBatch, text, new Vector2(location.X + shadowDistance, location.Y + shadowDistance), shadowColor, scale, depth);
-            fonts[fontIndex].DrawString(spriteBatch, text, location, color, scale, depth);
-        }
-
-        public static void DrawRectangle(Rectangle rect, Color color, int thickness = 1)
-        {
-            spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y, rect.Width, thickness), color);
-            spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y + thickness, thickness, rect.Height - thickness), color);
-            spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X + rect.Width - thickness, rect.Y, thickness, rect.Height), color);
-            spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y + rect.Height - thickness, rect.Width, thickness), color);
-        }
-
-        public static void FillRectangle(Rectangle rect, Color color)
-        {
-            spriteBatch.Draw(whitePixelTexture, rect, color);
-        }
-
-        public static Vector2 GetTextDimensions(string text, int fontIndex)
-        {
-            if (fontIndex < 0 || fontIndex >= fonts.Count)
-                throw new IndexOutOfRangeException("Invalid font index: " + fontIndex);
-
-            return fonts[fontIndex].MeasureString(text);
-        }
-
-        public static void DrawLine(Vector2 start, Vector2 end, Color color, int thickness = 1, float depth = 0f)
-        {
-            Vector2 line = end - start;
-            if (thickness > 1)
-            {
-                Vector2 offset = RMath.VectorFromLengthAndAngle(thickness / 2, RMath.AngleFromVector(line) - (float)Math.PI / 2.0f);
-                end += offset;
-                start += offset;
-            }
-
-            spriteBatch.Draw(whitePixelTexture,
-                new Rectangle((int)start.X, (int)start.Y, (int)line.Length(), thickness),
-                null, color, (float)Math.Atan2(line.Y, line.X), new Vector2(0, 0), SpriteEffects.None, depth);
-        }
-
-        #endregion
+    public static void ChangeSettings(SpriteBatchSettings settings)
+    {
+        EndDraw();
+        CurrentSettings = settings;
+        BeginDrawInternal(CurrentSettings);
     }
+
+    /// <summary>
+    /// Prepares the renderer for drawing a batch of sprites.
+    /// </summary>
+    public static void BeginDraw()
+    {
+        BeginDrawInternal(CurrentSettings);
+    }
+
+    /// <summary>
+    /// Draws the currently queued batch of sprites.
+    /// </summary>
+    public static void EndDraw()
+    {
+        spriteBatch.End();
+    }
+
+    public static void PushRenderTarget(RenderTarget2D renderTarget) => RenderTargetStack.PushRenderTarget(renderTarget,
+        new SpriteBatchSettings(SpriteSortMode.Deferred, BlendState.AlphaBlend, null, null, null, null));
+
+    public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2) =>
+        RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2);
+
+    public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2, RenderTarget2D renderTarget3) =>
+        RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2, renderTarget3);
+
+    public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2, RenderTarget2D renderTarget3, RenderTarget2D renderTarget4) =>
+        RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2, renderTarget3, renderTarget4);
+
+    public static void PushRenderTarget(RenderTarget2D renderTarget, SpriteBatchSettings settings) => RenderTargetStack.PushRenderTarget(renderTarget, settings);
+
+    public static void PopRenderTarget() => RenderTargetStack.PopRenderTarget();
+
+    //BlendState blendState = new BlendState();
+    //blendState.AlphaDestinationBlend = Blend.One;
+    //blendState.ColorDestinationBlend = Blend.InverseSourceAlpha;
+    //blendState.AlphaSourceBlend = Blend.SourceAlpha;
+    //blendState.ColorSourceBlend = Blend.SourceAlpha;
+
+    internal static void BeginDrawInternal(SpriteBatchSettings settings) =>
+        BeginDrawInternal(settings.SpriteSortMode, settings.BlendState, settings.SamplerState, settings.DepthStencilState, settings.RasterizerState, settings.Effect);
+
+    internal static void BeginDrawInternal(SpriteSortMode ssm, BlendState bs, SamplerState ss, DepthStencilState dss, RasterizerState rs, Effect effect)
+    {
+#if XNA
+        spriteBatch.Begin(ssm, bs, ss, DepthStencilState.Default, RasterizerState.CullNone);
+#else
+        spriteBatch.Begin(ssm, bs, ss, dss, rs, effect);
+#endif
+    }
+
+    internal static void PushSettingsInternal()
+    {
+        settingStack.AddFirst(CurrentSettings);
+    }
+
+    internal static void PopSettingsInternal()
+    {
+        CurrentSettings = settingStack.First.Value;
+        settingStack.RemoveFirst();
+    }
+
+    internal static void ClearStack()
+    {
+        settingStack.Clear();
+    }
+
+    #region Rendering code
+
+    public static void DrawTexture(Texture2D texture, Rectangle rectangle, Color color)
+    {
+        spriteBatch.Draw(texture, rectangle, color);
+    }
+
+    public static void DrawTexture(Texture2D texture, Rectangle sourceRectangle, Rectangle destinationRectangle, Color color)
+    {
+        spriteBatch.Draw(texture, destinationRectangle, sourceRectangle, color);
+    }
+
+    public static void DrawTexture(Texture2D texture, Rectangle sourceRectangle, Vector2 location, float rotation, Vector2 origin, Vector2 scale, Color color, float layerDepth = 0f)
+    {
+        spriteBatch.Draw(texture, location, sourceRectangle, color, rotation, origin, scale, SpriteEffects.None, layerDepth);
+    }
+
+    public static void DrawTexture(Texture2D texture, Rectangle destinationRectangle, Rectangle? sourceRectangle, Color color, float rotation, Vector2 origin, SpriteEffects effects, float layerDepth)
+    {
+        spriteBatch.Draw(texture, destinationRectangle, sourceRectangle, color, rotation, origin, effects, layerDepth);
+    }
+
+    public static void DrawTexture(Texture2D texture, Vector2 location, float rotation, Vector2 origin, Vector2 scale, Color color, float layerDepth = 0f)
+    {
+        spriteBatch.Draw(texture, location, null, color, rotation, origin, scale, SpriteEffects.None, layerDepth);
+    }
+
+    /// <summary>
+    /// Draws a circle's perimiter.
+    /// </summary>
+    /// <param name="position">The center point of the circle.</param>
+    /// <param name="radius">The radius of the circle.</param>
+    /// <param name="color">The color of the circle.</param>
+    /// <param name="precision">Defines how smooth the circle's perimiter is. 
+    /// Larger values make the circle smoother, but have a larger effect on performance.</param>
+    /// <param name="thickness">The thickness of the perimiter.</param>
+    public static void DrawCircle(Vector2 position, float radius, Color color, int precision = 8, int thickness = 1)
+    {
+        float angle = 0f;
+        float increase = (float)Math.PI * 2f / precision;
+
+        Vector2 point = position + RMath.VectorFromLengthAndAngle(radius, angle);
+
+        for (int i = 0; i <= precision; i++)
+        {
+            Vector2 nextPoint = position + RMath.VectorFromLengthAndAngle(radius, angle);
+            DrawLine(point, nextPoint, color, thickness);
+            point = nextPoint;
+            angle += increase;
+        }
+    }
+
+    /// <summary>
+    /// Draws a circle where the circle's perimeter is dotted with a texture.
+    /// </summary>
+    /// <param name="position">The center point of the circle.</param>
+    /// <param name="radius">The radius of the circle.</param>
+    /// <param name="texture">The texture to dot the circle's perimiter with.</param>
+    /// <param name="color">The remap color of the texture.</param>
+    /// <param name="precision">How many times the texture is drawn on the perimiter.</param>
+    /// <param name="scale">The scale of the drawn texture compared to the size of the texture itself.</param>
+    /// <param name="layerDepth">The depth of the texture.</param>
+    public static void DrawCircleWithTexture(Vector2 position, float radius,
+        Texture2D texture, Color color, int precision = 8, float scale = 1f, float layerDepth = 0f)
+    {
+        float angle = 0f;
+        float increase = (float)Math.PI * 2f / precision;
+
+        Vector2 point = position + RMath.VectorFromLengthAndAngle(radius, angle);
+
+        for (int i = 0; i <= precision; i++)
+        {
+            DrawTexture(texture, point, 0f,
+                new Vector2(texture.Width / 2f, texture.Height / 2f),
+                new Vector2(scale, scale), color, layerDepth);
+            point = position + RMath.VectorFromLengthAndAngle(radius, angle);
+            angle += increase;
+        }
+    }
+
+    public static void DrawString(string text, int fontIndex, Vector2 location, Color color, float scale = 1.0f, float depth = 0f)
+    {
+        if (fontIndex < 0 || fontIndex >= fonts.Count)
+            throw new IndexOutOfRangeException("Invalid font index: " + fontIndex);
+
+        fonts[fontIndex].DrawString(spriteBatch, text, location, color, scale, depth);
+    }
+
+    public static void DrawStringWithShadow(string text, int fontIndex, Vector2 location, Color color, float scale = 1.0f, float shadowDistance = 1.0f, float depth = 0f)
+    {
+        if (fontIndex < 0 || fontIndex >= fonts.Count)
+            throw new IndexOutOfRangeException("Invalid font index: " + fontIndex);
+
+        Color shadowColor;
+#if XNA
+        shadowColor = new Color(0, 0, 0, color.A);
+#else
+        shadowColor = UISettings.ActiveSettings.TextShadowColor * (color.A / 255.0f);
+#endif
+
+        fonts[fontIndex].DrawString(spriteBatch, text, new Vector2(location.X + shadowDistance, location.Y + shadowDistance), shadowColor, scale, depth);
+        fonts[fontIndex].DrawString(spriteBatch, text, location, color, scale, depth);
+    }
+
+    public static void DrawRectangle(Rectangle rect, Color color, int thickness = 1)
+    {
+        spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y, rect.Width, thickness), color);
+        spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y + thickness, thickness, rect.Height - thickness), color);
+        spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X + rect.Width - thickness, rect.Y, thickness, rect.Height), color);
+        spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y + rect.Height - thickness, rect.Width, thickness), color);
+    }
+
+    public static void FillRectangle(Rectangle rect, Color color)
+    {
+        spriteBatch.Draw(whitePixelTexture, rect, color);
+    }
+
+    public static Vector2 GetTextDimensions(string text, int fontIndex)
+    {
+        if (fontIndex < 0 || fontIndex >= fonts.Count)
+            throw new IndexOutOfRangeException("Invalid font index: " + fontIndex);
+
+        return fonts[fontIndex].MeasureString(text);
+    }
+
+    public static void DrawLine(Vector2 start, Vector2 end, Color color, int thickness = 1, float depth = 0f)
+    {
+        Vector2 line = end - start;
+        if (thickness > 1)
+        {
+            Vector2 offset = RMath.VectorFromLengthAndAngle(thickness / 2, RMath.AngleFromVector(line) - (float)Math.PI / 2.0f);
+            end += offset;
+            start += offset;
+        }
+
+        spriteBatch.Draw(whitePixelTexture,
+            new Rectangle((int)start.X, (int)start.Y, (int)line.Length(), thickness),
+            null, color, (float)Math.Atan2(line.Y, line.X), new Vector2(0, 0), SpriteEffects.None, depth);
+    }
+
+    #endregion
+}

--- a/Renderer.cs
+++ b/Renderer.cs
@@ -6,90 +6,229 @@ using Microsoft.Xna.Framework.Content;
 using System.Text;
 using Rampastring.Tools;
 using System.Globalization;
+using FontStashSharp;
+using System.IO;
 #if XNA
 using System.Reflection;
 #endif
 
 namespace Rampastring.XNAUI;
-
-public struct SpriteBatchSettings
-{
-    public SpriteBatchSettings(SpriteSortMode ssm, BlendState bs, SamplerState ss, DepthStencilState dss, RasterizerState rs, Effect effect)
+    public struct SpriteBatchSettings
     {
-        SpriteSortMode = ssm;
-        BlendState = bs;
-        SamplerState = ss;
-        DepthStencilState = dss;
-        RasterizerState = rs;
-        Effect = effect;
+        public SpriteBatchSettings(SpriteSortMode ssm, BlendState bs, SamplerState ss, DepthStencilState dss, RasterizerState rs, Effect effect)
+        {
+            SpriteSortMode = ssm;
+            BlendState = bs;
+            SamplerState = ss;
+            DepthStencilState = dss;
+            RasterizerState = rs;
+            Effect = effect;
+        }
+
+        public readonly SpriteSortMode SpriteSortMode;
+        public readonly SamplerState SamplerState;
+        public readonly BlendState BlendState;
+        public readonly DepthStencilState DepthStencilState;
+        public readonly RasterizerState RasterizerState;
+        public readonly Effect Effect;
     }
 
-    public readonly SpriteSortMode SpriteSortMode;
-    public readonly SamplerState SamplerState;
-    public readonly BlendState BlendState;
-    public readonly DepthStencilState DepthStencilState;
-    public readonly RasterizerState RasterizerState;
-    public readonly Effect Effect;
-}
-
-/// <summary>
-/// Provides static methods for drawing.
-/// </summary>
-public static class Renderer
-{
-    private static SpriteBatch spriteBatch;
-
-    private static List<SpriteFont> fonts;
-
-    private static Texture2D whitePixelTexture;
-
-    private static readonly LinkedList<SpriteBatchSettings> settingStack = new LinkedList<SpriteBatchSettings>();
-
-    internal static SpriteBatchSettings CurrentSettings;
-
-    public static SpriteBatchSettings GetCurrentSettings() => CurrentSettings;
-
-    public static void Initialize(GraphicsDevice gd, ContentManager content)
+    public abstract class IFont
     {
-        spriteBatch = new SpriteBatch(gd);
-        fonts = new List<SpriteFont>();
-        LoadFonts(content);
-
-        whitePixelTexture = AssetLoader.CreateTexture(Color.White, 1, 1);
+        public abstract Vector2 MeasureString(string text);
+        public abstract void DrawString(SpriteBatch spriteBatch, string text, Vector2 location, Color color, float scale, float depth);
+        public abstract void DrawString(SpriteBatch spriteBatch, StringSegment text, Vector2 location, Color color, float rotation, Vector2 origin, Vector2 scale, float depth);
+        public abstract bool HasCharacter(char c);
+        public abstract string GetSafeString(string str);
     }
 
     /// <summary>
-    /// Clears all potentially existing loaded fonts and then loads fonts from asset loader directories.
+    /// A wrapper for the classic XNA SpriteFont.
     /// </summary>
-    /// <param name="contentManager">A XNA/MonoGame ContentManager instance.</param>
-    public static void LoadFonts(ContentManager contentManager)
+    public class SpriteFontWrapper : IFont
     {
-        if (fonts == null)
-            fonts = new List<SpriteFont>();
-        else
-            fonts.Clear();
+        internal readonly SpriteFont _font;
 
-        string originalContentRoot = contentManager.RootDirectory;
+        public SpriteFontWrapper(SpriteFont font)
+        {
+            _font = font;
+        }
 
+        public override Vector2 MeasureString(string text) => _font.MeasureString(text);
+
+        public override void DrawString(SpriteBatch spriteBatch, string text, Vector2 location, Color color, float scale, float depth) =>
+            spriteBatch.DrawString(_font, text, location, color, 0f, Vector2.Zero, scale, SpriteEffects.None, depth);
+
+        public override void DrawString(SpriteBatch spriteBatch, StringSegment text, Vector2 location, Color color, float rotation, Vector2 origin, Vector2 scale, float depth) =>
+            spriteBatch.DrawString(_font, text.ToString(), location, color, rotation, origin, scale.X, SpriteEffects.None, depth);
+
+        public override bool HasCharacter(char c) => _font.Characters.Contains(c);
+
+        public override string GetSafeString(string str)
+        {
+            var sb = new StringBuilder(str);
+            for (int i = 0; i < str.Length; i++)
+            {
+                char c = str[i];
+                if (c != '\r' && c != '\n' && !HasCharacter(c))
+                {
+                    sb.Replace(c, '?');
+                }
+            }
+            return sb.ToString();
+        }
+    }
+
+    /// <summary>
+    /// A wrapper for the FontStashSharp TTF fonts.
+    /// </summary>
+    public class TTFFontWrapper : IFont
+    {
+        internal readonly SpriteFontBase _font;
+
+        public TTFFontWrapper(SpriteFontBase font)
+        {
+            _font = font;
+        }
+
+        public override Vector2 MeasureString(string text)
+        {
+            var bounds = _font.MeasureString(text);
+            return new Vector2(bounds.X, bounds.Y);
+        }
+
+        public override void DrawString(SpriteBatch spriteBatch, string text, Vector2 location, Color color, float scale, float depth)
+        {
+            var vectorScale = new Vector2(scale, scale);
+            var segment = new StringSegment(text);
+            spriteBatch.DrawString(_font, segment, location, color, 0f, Vector2.Zero, vectorScale, depth);
+        }
+
+        public override void DrawString(SpriteBatch spriteBatch, StringSegment text, Vector2 location, Color color, float rotation, Vector2 origin, Vector2 scale, float depth) =>
+            spriteBatch.DrawString(_font, text, location, color, rotation, origin, scale, depth);
+
+        public override bool HasCharacter(char c) => true;
+
+        public override string GetSafeString(string str)
+        {
+            var sb = new StringBuilder(str);
+            for (int i = 0; i < str.Length; i++)
+            {
+                char c = str[i];
+                if (!char.IsControl(c) || c == '\r' || c == '\n')
+                {
+                    continue;
+                }
+                sb.Replace(c, '?');
+            }
+            return sb.ToString();
+        }
+    }
+
+    public static class Renderer
+    {
+        private static SpriteBatch spriteBatch;
+        private static List<IFont> fonts;
+        private static FontSystem fontSystem;
+
+        private static Texture2D whitePixelTexture;
+
+        private static readonly LinkedList<SpriteBatchSettings> settingStack = new LinkedList<SpriteBatchSettings>();
+
+        internal static SpriteBatchSettings CurrentSettings;
+
+        public static SpriteBatchSettings GetCurrentSettings() => CurrentSettings;
+
+        public static void Initialize(GraphicsDevice gd, ContentManager content)
+        {
+            spriteBatch = new SpriteBatch(gd);
+            fonts = new List<IFont>();
+            LoadFonts(content);
+
+            whitePixelTexture = AssetLoader.CreateTexture(Color.White, 1, 1);
+        }
+
+        /// <summary>
+        /// Clears all potentially existing loaded fonts and then loads fonts from asset loader directories.
+        /// </summary>
+        /// <param name="contentManager">A XNA/MonoGame ContentManager instance.</param>
+        public static void LoadFonts(ContentManager contentManager)
+        {
+            if (fonts == null)
+                fonts = new List<IFont>();
+            else
+                fonts.Clear();
+
+            fontSystem = new FontSystem();
+            string originalContentRoot = contentManager.RootDirectory;
 #if XNA
-        var contentManagerType = contentManager.GetType();
-        var rootDirectoryField = contentManagerType.GetField("rootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
-        var fullRootDirectoryField = contentManager.GetType().GetField("fullRootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
+    var contentManagerType = contentManager.GetType();
+    var rootDirectoryField = contentManagerType.GetField("rootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
+    var fullRootDirectoryField = contentManager.GetType().GetField("fullRootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
 #endif
 
-        foreach (string searchPath in AssetLoader.AssetSearchPaths)
-        {
-            string newRootDirectory = SafePath.GetDirectory(searchPath).FullName;
-
-            while (true)
+            foreach (string searchPath in AssetLoader.AssetSearchPaths)
             {
-                string sfName = string.Format(CultureInfo.InvariantCulture, "SpriteFont{0}", fonts.Count);
+                string baseDir = SafePath.GetDirectory(searchPath).FullName;
+                string iniPath = Path.Combine(baseDir, "Fonts.ini");
 
-                if (!SafePath.GetFile(searchPath, FormattableString.Invariant($"{sfName}.xnb")).Exists)
-                    break;
+                if (File.Exists(iniPath))
+                {
+                    var iniFile = new IniFile(iniPath);
+                    int fontCount = iniFile.GetIntValue("Fonts", "Count", 0);
+
+                    for (int i = 0; i < fontCount; i++)
+                    {
+                        string section = $"Font{i}";
+                        string fontType = iniFile.GetStringValue(section, "Type", "SpriteFont");
+                        string fontPath = iniFile.GetStringValue(section, "Path", "");
+                        int size = iniFile.GetIntValue(section, "Size", 16);
+
+                        if (string.Equals(fontType, "TrueType", StringComparison.OrdinalIgnoreCase))
+                        {
+                            string fullFontPath = SafePath.GetFile(searchPath, fontPath).FullName;
+                            if (File.Exists(fullFontPath))
+                            {
+                                fontSystem.AddFont(File.ReadAllBytes(fullFontPath));
+                                fonts.Add(new TTFFontWrapper(fontSystem.GetFont(size)));
+                            }
+                            else
+                                Logger.Log($"TTF font file not found: {fullFontPath}");
+                        }
+                        else
+                        {
+                            string newRootDirectory = baseDir;
+#if !XNA
+                            contentManager.RootDirectory = newRootDirectory;
+#else
+                    rootDirectoryField.SetValue(contentManager, newRootDirectory);
+                    fullRootDirectoryField.SetValue(contentManager, newRootDirectory);
+#endif
+                            string sfName = Path.GetFileNameWithoutExtension(fontPath);
+                            if (SafePath.GetFile(searchPath, $"{sfName}.xnb").Exists)
+                            {
+                                fonts.Add(new SpriteFontWrapper(contentManager.Load<SpriteFont>(sfName)));
+                                Logger.Log($"Loaded SpriteFont: {sfName}");
+                            }
+                            else
+                            {
+                                Logger.Log($"SpriteFont file not found: {sfName}.xnb");
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    string newRootDirectory = baseDir;
+                    while (true)
+                    {
+                        string sfName = string.Format(CultureInfo.InvariantCulture, "SpriteFont{0}", fonts.Count);
+
+                        if (!SafePath.GetFile(searchPath, FormattableString.Invariant($"{sfName}.xnb")).Exists)
+                            break;
 
 #if !XNA
-                contentManager.RootDirectory = newRootDirectory;
+                        contentManager.RootDirectory = newRootDirectory;
 #else
                 // XNA does not allow changing the value of RootDirectory after the
                 // content manager has been used. However, it has some internal fields
@@ -103,76 +242,77 @@ public static class Renderer
                 fullRootDirectoryField.SetValue(contentManager, newRootDirectory);
 #endif
 
-                fonts.Add(contentManager.Load<SpriteFont>(sfName));
+                        fonts.Add(new SpriteFontWrapper(contentManager.Load<SpriteFont>(sfName)));
+                    }
+                }
             }
-        }
 
 #if !XNA
-        contentManager.RootDirectory = originalContentRoot;
+            contentManager.RootDirectory = originalContentRoot;
 #else
-        rootDirectoryField.SetValue(contentManager, originalContentRoot);
-        fullRootDirectoryField.SetValue(contentManager, originalContentRoot);
+    rootDirectoryField.SetValue(contentManager, originalContentRoot);
+    fullRootDirectoryField.SetValue(contentManager, originalContentRoot);
 #endif
-    }
-
-
-    /// <summary>
-    /// Allows direct access to the list of loaded fonts.
-    /// </summary>
-    public static List<SpriteFont> GetFontList() => fonts;
-
-    /// <summary>
-    /// Returns a version of the given string where all characters that don't
-    /// appear in the given font have been replaced with question marks.
-    /// </summary>
-    /// <param name="str">The string.</param>
-    /// <param name="fontIndex">The index of the font.</param>
-    public static string GetSafeString(string str, int fontIndex)
-    {
-        SpriteFont sf = fonts[fontIndex];
-
-        var sb = new StringBuilder(str);
-
-        for (int i = 0; i < str.Length; i++)
-        {
-            char c = str[i];
-
-            if (c != '\r' && c != '\n' && !sf.Characters.Contains(c))
-                sb.Replace(c, '?');
         }
 
-        return sb.ToString();
-    }
 
-    /// <summary>
-    /// Returns a that has had its width limited to a specific number.
-    /// Characters that'd cross over the width have been cut.
-    /// </summary>
-    /// <param name="str">The string to limit.</param>
-    /// <param name="fontIndex">The index of the font to use.</param>
-    /// <param name="maxWidth">The maximum width of the string.</param>
-    /// <returns></returns>
-    public static string GetStringWithLimitedWidth(string str, int fontIndex, int maxWidth)
-    {
-        var sb = new StringBuilder(str);
-        var spriteFont = fonts[fontIndex];
+        /// <summary>
+        /// Allows direct access to the list of loaded fonts.
+        /// </summary>
+        public static List<IFont> GetFontList() => fonts;
 
-        while (spriteFont.MeasureString(sb.ToString()).X > maxWidth)
+        /// <summary>
+        /// Returns a version of the given string where all characters that don't
+        /// appear in the given font have been replaced with question marks.
+        /// </summary>
+        /// <param name="str">The string.</param>
+        /// <param name="fontIndex">The index of the font.</param>
+        public static string GetSafeString(string str, int fontIndex)
         {
-            sb.Remove(sb.Length - 1, 1);
+            if (fontIndex < 0 || fontIndex >= fonts.Count)
+                throw new IndexOutOfRangeException("Invalid font index.");
+
+            return fonts[fontIndex].GetSafeString(str);
         }
 
-        return sb.ToString();
-    }
+        /// <summary>
+        /// Returns a that has had its width limited to a specific number.
+        /// Characters that'd cross over the width have been cut.
+        /// </summary>
+        /// <param name="str">The string to limit.</param>
+        /// <param name="fontIndex">The index of the font to use.</param>
+        /// <param name="maxWidth">The maximum width of the string.</param>
+        /// <returns></returns>
+        public static string GetStringWithLimitedWidth(string str, int fontIndex, int maxWidth)
+        {
+            if (fontIndex < 0 || fontIndex >= fonts.Count)
+                throw new IndexOutOfRangeException("Invalid font index.");
+
+            var font = fonts[fontIndex];
+            var sb = new StringBuilder(str);
+            while (font.MeasureString(sb.ToString()).X > maxWidth && sb.Length > 0)
+            {
+                sb.Remove(sb.Length - 1, 1);
+            }
+            return sb.ToString();
+        }
 
     public static TextParseReturnValue FixText(string text, int fontIndex, int width)
     {
-        return TextParseReturnValue.FixText(fonts[fontIndex], width, text);
+        if (fontIndex < 0 || fontIndex >= fonts.Count)
+            throw new IndexOutOfRangeException("Invalid font index.");
+
+        IFont font = fonts[fontIndex];
+        return TextParseReturnValue.FixText(font, width, text);
     }
 
     public static List<string> GetFixedTextLines(string text, int fontIndex, int width, bool splitWords = true, bool keepBlankLines = false)
     {
-        return TextParseReturnValue.GetFixedTextLines(fonts[fontIndex], width, text, splitWords, keepBlankLines);
+        if (fontIndex < 0 || fontIndex >= fonts.Count)
+            throw new IndexOutOfRangeException("Invalid font index.");
+
+        IFont font = fonts[fontIndex];
+        return TextParseReturnValue.GetFixedTextLines(font, width, text, splitWords, keepBlankLines);
     }
 
     /// <summary>
@@ -182,245 +322,242 @@ public static class Renderer
     /// </summary>
     /// <param name="settings">The sprite batch settings.</param>
     public static void PushSettings(SpriteBatchSettings settings)
-    {
-        EndDraw();
-        PushSettingsInternal();
-        CurrentSettings = settings;
-        BeginDrawInternal(CurrentSettings);
-    }
+        {
+            EndDraw();
+            PushSettingsInternal();
+            CurrentSettings = settings;
+            BeginDrawInternal(CurrentSettings);
+        }
 
-    /// <summary>
-    /// Pops previous settings from the renderer's internal stack and applies them.
-    /// </summary>
-    public static void PopSettings()
-    {
-        EndDraw();
-        PopSettingsInternal();
-        BeginDrawInternal(CurrentSettings);
-    }
+        /// <summary>
+        /// Pops previous settings from the renderer's internal stack and applies them.
+        /// </summary>
+        public static void PopSettings()
+        {
+            EndDraw();
+            PopSettingsInternal();
+            BeginDrawInternal(CurrentSettings);
+        }
 
-    /// <summary>
-    /// Changes current rendering settings. This can be called between 
-    /// <see cref="PushSettings(SpriteBatchSettings)"/> and <see cref="PopSettings"/>
-    /// when you want to draw something with new settings, but there's no reason 
-    /// to save those settings.
-    /// </summary>
-    /// <param name="settings">The sprite batch settings.</param>
-    public static void ChangeSettings(SpriteBatchSettings settings)
-    {
-        EndDraw();
-        CurrentSettings = settings;
-        BeginDrawInternal(CurrentSettings);
-    }
+        /// <summary>
+        /// Changes current rendering settings. This can be called between 
+        /// <see cref="PushSettings(SpriteBatchSettings)"/> and <see cref="PopSettings"/>
+        /// when you want to draw something with new settings, but there's no reason 
+        /// to save those settings.
+        /// </summary>
+        /// <param name="settings">The sprite batch settings.</param>
+        public static void ChangeSettings(SpriteBatchSettings settings)
+        {
+            EndDraw();
+            CurrentSettings = settings;
+            BeginDrawInternal(CurrentSettings);
+        }
 
-    /// <summary>
-    /// Prepares the renderer for drawing a batch of sprites.
-    /// </summary>
-    public static void BeginDraw()
-    {
-        BeginDrawInternal(CurrentSettings);
-    }
+        /// <summary>
+        /// Prepares the renderer for drawing a batch of sprites.
+        /// </summary>
+        public static void BeginDraw()
+        {
+            BeginDrawInternal(CurrentSettings);
+        }
 
-    /// <summary>
-    /// Draws the currently queued batch of sprites.
-    /// </summary>
-    public static void EndDraw()
-    {
-        spriteBatch.End();
-    }
+        /// <summary>
+        /// Draws the currently queued batch of sprites.
+        /// </summary>
+        public static void EndDraw()
+        {
+            spriteBatch.End();
+        }
 
-    public static void PushRenderTarget(RenderTarget2D renderTarget) => RenderTargetStack.PushRenderTarget(renderTarget,
-        new SpriteBatchSettings(SpriteSortMode.Deferred, BlendState.AlphaBlend, null, null, null, null));
+        public static void PushRenderTarget(RenderTarget2D renderTarget) => RenderTargetStack.PushRenderTarget(renderTarget,
+            new SpriteBatchSettings(SpriteSortMode.Deferred, BlendState.AlphaBlend, null, null, null, null));
 
-    public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2) =>
-        RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2);
+        public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2) =>
+            RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2);
 
-    public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2, RenderTarget2D renderTarget3) =>
-        RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2, renderTarget3);
+        public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2, RenderTarget2D renderTarget3) =>
+            RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2, renderTarget3);
 
-    public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2, RenderTarget2D renderTarget3, RenderTarget2D renderTarget4) => 
-        RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2, renderTarget3, renderTarget4);
+        public static void PushRenderTargets(RenderTarget2D renderTarget, RenderTarget2D renderTarget2, RenderTarget2D renderTarget3, RenderTarget2D renderTarget4) =>
+            RenderTargetStack.PushRenderTargets(CurrentSettings, renderTarget, renderTarget2, renderTarget3, renderTarget4);
 
-    public static void PushRenderTarget(RenderTarget2D renderTarget, SpriteBatchSettings settings) => RenderTargetStack.PushRenderTarget(renderTarget, settings);
+        public static void PushRenderTarget(RenderTarget2D renderTarget, SpriteBatchSettings settings) => RenderTargetStack.PushRenderTarget(renderTarget, settings);
 
-    public static void PopRenderTarget() => RenderTargetStack.PopRenderTarget();
+        public static void PopRenderTarget() => RenderTargetStack.PopRenderTarget();
 
-    //BlendState blendState = new BlendState();
-    //blendState.AlphaDestinationBlend = Blend.One;
-    //blendState.ColorDestinationBlend = Blend.InverseSourceAlpha;
-    //blendState.AlphaSourceBlend = Blend.SourceAlpha;
-    //blendState.ColorSourceBlend = Blend.SourceAlpha;
+        //BlendState blendState = new BlendState();
+        //blendState.AlphaDestinationBlend = Blend.One;
+        //blendState.ColorDestinationBlend = Blend.InverseSourceAlpha;
+        //blendState.AlphaSourceBlend = Blend.SourceAlpha;
+        //blendState.ColorSourceBlend = Blend.SourceAlpha;
 
-    internal static void BeginDrawInternal(SpriteBatchSettings settings) =>
-        BeginDrawInternal(settings.SpriteSortMode, settings.BlendState, settings.SamplerState, settings.DepthStencilState, settings.RasterizerState, settings.Effect);
+        internal static void BeginDrawInternal(SpriteBatchSettings settings) =>
+            BeginDrawInternal(settings.SpriteSortMode, settings.BlendState, settings.SamplerState, settings.DepthStencilState, settings.RasterizerState, settings.Effect);
 
-    internal static void BeginDrawInternal(SpriteSortMode ssm, BlendState bs, SamplerState ss, DepthStencilState dss, RasterizerState rs, Effect effect)
-    {
+        internal static void BeginDrawInternal(SpriteSortMode ssm, BlendState bs, SamplerState ss, DepthStencilState dss, RasterizerState rs, Effect effect)
+        {
 #if XNA
-        spriteBatch.Begin(ssm, bs, ss, DepthStencilState.Default, RasterizerState.CullNone);
+            spriteBatch.Begin(ssm, bs, ss, DepthStencilState.Default, RasterizerState.CullNone);
 #else
-        spriteBatch.Begin(ssm, bs, ss, dss, rs, effect);
+            spriteBatch.Begin(ssm, bs, ss, dss, rs, effect);
 #endif
-    }
-
-    internal static void PushSettingsInternal()
-    {
-        settingStack.AddFirst(CurrentSettings);
-    }
-
-    internal static void PopSettingsInternal()
-    {
-        CurrentSettings = settingStack.First.Value;
-        settingStack.RemoveFirst();
-    }
-
-    internal static void ClearStack()
-    {
-        settingStack.Clear();
-    }
-
-#region Rendering code
-
-    public static void DrawTexture(Texture2D texture, Rectangle rectangle, Color color)
-    {
-        spriteBatch.Draw(texture, rectangle, color);
-    }
-
-    public static void DrawTexture(Texture2D texture, Rectangle sourceRectangle, Rectangle destinationRectangle, Color color)
-    {
-        spriteBatch.Draw(texture, destinationRectangle, sourceRectangle, color);
-    }
-
-    public static void DrawTexture(Texture2D texture, Rectangle sourceRectangle, Vector2 location, float rotation, Vector2 origin, Vector2 scale, Color color, float layerDepth = 0f)
-    {
-        spriteBatch.Draw(texture, location, sourceRectangle, color, rotation, origin, scale, SpriteEffects.None, layerDepth);
-    }
-
-    public static void DrawTexture(Texture2D texture, Rectangle destinationRectangle, Rectangle? sourceRectangle, Color color, float rotation, Vector2 origin, SpriteEffects effects, float layerDepth)
-    {
-        spriteBatch.Draw(texture, destinationRectangle, sourceRectangle, color, rotation, origin, effects, layerDepth);
-    }
-
-    public static void DrawTexture(Texture2D texture, Vector2 location, float rotation, Vector2 origin, Vector2 scale, Color color, float layerDepth = 0f)
-    {
-        spriteBatch.Draw(texture, location, null, color, rotation, origin, scale, SpriteEffects.None, layerDepth);
-    }
-
-    /// <summary>
-    /// Draws a circle's perimiter.
-    /// </summary>
-    /// <param name="position">The center point of the circle.</param>
-    /// <param name="radius">The radius of the circle.</param>
-    /// <param name="color">The color of the circle.</param>
-    /// <param name="precision">Defines how smooth the circle's perimiter is. 
-    /// Larger values make the circle smoother, but have a larger effect on performance.</param>
-    /// <param name="thickness">The thickness of the perimiter.</param>
-    public static void DrawCircle(Vector2 position, float radius, Color color, int precision = 8, int thickness = 1)
-    {
-        float angle = 0f;
-        float increase = (float)Math.PI * 2f / precision;
-
-        Vector2 point = position + RMath.VectorFromLengthAndAngle(radius, angle);
-
-        for (int i = 0; i <= precision; i++)
-        {
-            Vector2 nextPoint = position + RMath.VectorFromLengthAndAngle(radius, angle);
-            DrawLine(point, nextPoint, color, thickness);
-            point = nextPoint;
-            angle += increase;
         }
-    }
 
-    /// <summary>
-    /// Draws a circle where the circle's perimeter is dotted with a texture.
-    /// </summary>
-    /// <param name="position">The center point of the circle.</param>
-    /// <param name="radius">The radius of the circle.</param>
-    /// <param name="texture">The texture to dot the circle's perimiter with.</param>
-    /// <param name="color">The remap color of the texture.</param>
-    /// <param name="precision">How many times the texture is drawn on the perimiter.</param>
-    /// <param name="scale">The scale of the drawn texture compared to the size of the texture itself.</param>
-    /// <param name="layerDepth">The depth of the texture.</param>
-    public static void DrawCircleWithTexture(Vector2 position, float radius,
-        Texture2D texture, Color color, int precision = 8, float scale = 1f, float layerDepth = 0f)
-    {
-        float angle = 0f;
-        float increase = (float)Math.PI * 2f / precision;
-
-        Vector2 point = position + RMath.VectorFromLengthAndAngle(radius, angle);
-
-        for (int i = 0; i <= precision; i++)
+        internal static void PushSettingsInternal()
         {
-            DrawTexture(texture, point, 0f,
-                new Vector2(texture.Width / 2f, texture.Height / 2f),
-                new Vector2(scale, scale), color, layerDepth);
-            point = position + RMath.VectorFromLengthAndAngle(radius, angle);
-            angle += increase;
+            settingStack.AddFirst(CurrentSettings);
         }
-    }
 
-    public static void DrawString(string text, int fontIndex, Vector2 location, Color color, float scale = 1.0f, float depth = 0f)
-    {
-        if (fontIndex >= fonts.Count)
-            throw new Exception("Invalid font index: " + fontIndex);
+        internal static void PopSettingsInternal()
+        {
+            CurrentSettings = settingStack.First.Value;
+            settingStack.RemoveFirst();
+        }
 
-        spriteBatch.DrawString(fonts[fontIndex], text, location, color, 0f, Vector2.Zero, scale, SpriteEffects.None, depth);
-    }
+        internal static void ClearStack()
+        {
+            settingStack.Clear();
+        }
 
-    public static void DrawStringWithShadow(string text, int fontIndex, Vector2 location, Color color, float scale = 1.0f, float shadowDistance = 1.0f, float depth = 0f)
-    {
-        if (fontIndex >= fonts.Count)
-            throw new Exception("Invalid font index: " + fontIndex);
+        #region Rendering code
 
+        public static void DrawTexture(Texture2D texture, Rectangle rectangle, Color color)
+        {
+            spriteBatch.Draw(texture, rectangle, color);
+        }
+
+        public static void DrawTexture(Texture2D texture, Rectangle sourceRectangle, Rectangle destinationRectangle, Color color)
+        {
+            spriteBatch.Draw(texture, destinationRectangle, sourceRectangle, color);
+        }
+
+        public static void DrawTexture(Texture2D texture, Rectangle sourceRectangle, Vector2 location, float rotation, Vector2 origin, Vector2 scale, Color color, float layerDepth = 0f)
+        {
+            spriteBatch.Draw(texture, location, sourceRectangle, color, rotation, origin, scale, SpriteEffects.None, layerDepth);
+        }
+
+        public static void DrawTexture(Texture2D texture, Rectangle destinationRectangle, Rectangle? sourceRectangle, Color color, float rotation, Vector2 origin, SpriteEffects effects, float layerDepth)
+        {
+            spriteBatch.Draw(texture, destinationRectangle, sourceRectangle, color, rotation, origin, effects, layerDepth);
+        }
+
+        public static void DrawTexture(Texture2D texture, Vector2 location, float rotation, Vector2 origin, Vector2 scale, Color color, float layerDepth = 0f)
+        {
+            spriteBatch.Draw(texture, location, null, color, rotation, origin, scale, SpriteEffects.None, layerDepth);
+        }
+
+        /// <summary>
+        /// Draws a circle's perimiter.
+        /// </summary>
+        /// <param name="position">The center point of the circle.</param>
+        /// <param name="radius">The radius of the circle.</param>
+        /// <param name="color">The color of the circle.</param>
+        /// <param name="precision">Defines how smooth the circle's perimiter is. 
+        /// Larger values make the circle smoother, but have a larger effect on performance.</param>
+        /// <param name="thickness">The thickness of the perimiter.</param>
+        public static void DrawCircle(Vector2 position, float radius, Color color, int precision = 8, int thickness = 1)
+        {
+            float angle = 0f;
+            float increase = (float)Math.PI * 2f / precision;
+
+            Vector2 point = position + RMath.VectorFromLengthAndAngle(radius, angle);
+
+            for (int i = 0; i <= precision; i++)
+            {
+                Vector2 nextPoint = position + RMath.VectorFromLengthAndAngle(radius, angle);
+                DrawLine(point, nextPoint, color, thickness);
+                point = nextPoint;
+                angle += increase;
+            }
+        }
+
+        /// <summary>
+        /// Draws a circle where the circle's perimeter is dotted with a texture.
+        /// </summary>
+        /// <param name="position">The center point of the circle.</param>
+        /// <param name="radius">The radius of the circle.</param>
+        /// <param name="texture">The texture to dot the circle's perimiter with.</param>
+        /// <param name="color">The remap color of the texture.</param>
+        /// <param name="precision">How many times the texture is drawn on the perimiter.</param>
+        /// <param name="scale">The scale of the drawn texture compared to the size of the texture itself.</param>
+        /// <param name="layerDepth">The depth of the texture.</param>
+        public static void DrawCircleWithTexture(Vector2 position, float radius,
+            Texture2D texture, Color color, int precision = 8, float scale = 1f, float layerDepth = 0f)
+        {
+            float angle = 0f;
+            float increase = (float)Math.PI * 2f / precision;
+
+            Vector2 point = position + RMath.VectorFromLengthAndAngle(radius, angle);
+
+            for (int i = 0; i <= precision; i++)
+            {
+                DrawTexture(texture, point, 0f,
+                    new Vector2(texture.Width / 2f, texture.Height / 2f),
+                    new Vector2(scale, scale), color, layerDepth);
+                point = position + RMath.VectorFromLengthAndAngle(radius, angle);
+                angle += increase;
+            }
+        }
+
+        public static void DrawString(string text, int fontIndex, Vector2 location, Color color, float scale = 1.0f, float depth = 0f)
+        {
+            if (fontIndex < 0 || fontIndex >= fonts.Count)
+                throw new IndexOutOfRangeException("Invalid font index: " + fontIndex);
+
+            fonts[fontIndex].DrawString(spriteBatch, text, location, color, scale, depth);
+        }
+
+        public static void DrawStringWithShadow(string text, int fontIndex, Vector2 location, Color color, float scale = 1.0f, float shadowDistance = 1.0f, float depth = 0f)
+        {
+            if (fontIndex < 0 || fontIndex >= fonts.Count)
+                throw new IndexOutOfRangeException("Invalid font index: " + fontIndex);
+
+            Color shadowColor;
 #if XNA
-        spriteBatch.DrawString(fonts[fontIndex], text,
-            new Vector2(location.X + shadowDistance, location.Y + shadowDistance),
-            new Color(0, 0, 0, color.A));
+            shadowColor = new Color(0, 0, 0, color.A);
 #else
-        spriteBatch.DrawString(fonts[fontIndex], text,
-            new Vector2(location.X + shadowDistance, location.Y + shadowDistance),
-            UISettings.ActiveSettings.TextShadowColor * (color.A / 255.0f),
-            0f, Vector2.Zero, scale, SpriteEffects.None, depth);
+            shadowColor = UISettings.ActiveSettings.TextShadowColor * (color.A / 255.0f);
 #endif
 
-        spriteBatch.DrawString(fonts[fontIndex], text, location, color, 0f, Vector2.Zero, scale, SpriteEffects.None, depth);
-    }
-
-    public static void DrawRectangle(Rectangle rect, Color color, int thickness = 1)
-    {
-        spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y, rect.Width, thickness), color);
-        spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y + thickness, thickness, rect.Height - thickness), color);
-        spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X + rect.Width - thickness, rect.Y, thickness, rect.Height), color);
-        spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y + rect.Height - thickness, rect.Width, thickness), color);
-    }
-
-    public static void FillRectangle(Rectangle rect, Color color)
-    {
-        spriteBatch.Draw(whitePixelTexture, rect, color);
-    }
-
-    public static Vector2 GetTextDimensions(string text, int fontIndex)
-    {
-        if (fontIndex >= fonts.Count)
-            throw new Exception("Invalid font index: " + fontIndex);
-
-        return fonts[fontIndex].MeasureString(text);
-    }
-
-    public static void DrawLine(Vector2 start, Vector2 end, Color color, int thickness = 1, float depth = 0f)
-    {
-        Vector2 line = end - start;
-        if (thickness > 1)
-        {
-            Vector2 offset = RMath.VectorFromLengthAndAngle(thickness / 2, RMath.AngleFromVector(line) - (float)Math.PI / 2.0f);
-            end += offset;
-            start += offset;
+            fonts[fontIndex].DrawString(spriteBatch, text, new Vector2(location.X + shadowDistance, location.Y + shadowDistance), shadowColor, scale, depth);
+            fonts[fontIndex].DrawString(spriteBatch, text, location, color, scale, depth);
         }
 
-        spriteBatch.Draw(whitePixelTexture,
-            new Rectangle((int)start.X, (int)start.Y, (int)line.Length(), thickness),
-            null, color, (float)Math.Atan2(line.Y, line.X), new Vector2(0, 0), SpriteEffects.None, depth);
-    }
+        public static void DrawRectangle(Rectangle rect, Color color, int thickness = 1)
+        {
+            spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y, rect.Width, thickness), color);
+            spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y + thickness, thickness, rect.Height - thickness), color);
+            spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X + rect.Width - thickness, rect.Y, thickness, rect.Height), color);
+            spriteBatch.Draw(whitePixelTexture, new Rectangle(rect.X, rect.Y + rect.Height - thickness, rect.Width, thickness), color);
+        }
 
-#endregion
-}
+        public static void FillRectangle(Rectangle rect, Color color)
+        {
+            spriteBatch.Draw(whitePixelTexture, rect, color);
+        }
+
+        public static Vector2 GetTextDimensions(string text, int fontIndex)
+        {
+            if (fontIndex < 0 || fontIndex >= fonts.Count)
+                throw new IndexOutOfRangeException("Invalid font index: " + fontIndex);
+
+            return fonts[fontIndex].MeasureString(text);
+        }
+
+        public static void DrawLine(Vector2 start, Vector2 end, Color color, int thickness = 1, float depth = 0f)
+        {
+            Vector2 line = end - start;
+            if (thickness > 1)
+            {
+                Vector2 offset = RMath.VectorFromLengthAndAngle(thickness / 2, RMath.AngleFromVector(line) - (float)Math.PI / 2.0f);
+                end += offset;
+                start += offset;
+            }
+
+            spriteBatch.Draw(whitePixelTexture,
+                new Rectangle((int)start.X, (int)start.Y, (int)line.Length(), thickness),
+                null, color, (float)Math.Atan2(line.Y, line.X), new Vector2(0, 0), SpriteEffects.None, depth);
+        }
+
+        #endregion
+    }

--- a/Renderer.cs
+++ b/Renderer.cs
@@ -162,9 +162,9 @@ public static class Renderer
         fontSystem = new FontSystem();
         string originalContentRoot = contentManager.RootDirectory;
 #if XNA
-var contentManagerType = contentManager.GetType();
-var rootDirectoryField = contentManagerType.GetField("rootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
-var fullRootDirectoryField = contentManager.GetType().GetField("fullRootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
+    var contentManagerType = contentManager.GetType();
+    var rootDirectoryField = contentManagerType.GetField("rootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
+    var fullRootDirectoryField = contentManager.GetType().GetField("fullRootDirectory", BindingFlags.Instance | BindingFlags.NonPublic | BindingFlags.SetField | BindingFlags.GetField);
 #endif
 
         foreach (string searchPath in AssetLoader.AssetSearchPaths)
@@ -230,15 +230,15 @@ var fullRootDirectoryField = contentManager.GetType().GetField("fullRootDirector
 #if !XNA
                     contentManager.RootDirectory = newRootDirectory;
 #else
-            // XNA does not allow changing the value of RootDirectory after the
-            // content manager has been used. However, it has some internal fields
-            // we can modify through reflection to achieve the same.
+        // XNA does not allow changing the value of RootDirectory after the
+        // content manager has been used. However, it has some internal fields
+        // we can modify through reflection to achieve the same.
 
-            // This would be a very bad solution when using a library that
-            // is updated regularly, but since XNA has been EOL for over a decade
-            // by this point, its internal logic is never going to change.
+        // This would be a very bad solution when using a library that
+        // is updated regularly, but since XNA has been EOL for over a decade
+        // by this point, its internal logic is never going to change.
 
-            rootDirectoryField.SetValue(contentManager, newRootDirectory);
+        rootDirectoryField.SetValue(contentManager, newRootDirectory);
             fullRootDirectoryField.SetValue(contentManager, newRootDirectory);
 #endif
 
@@ -250,8 +250,8 @@ var fullRootDirectoryField = contentManager.GetType().GetField("fullRootDirector
 #if !XNA
         contentManager.RootDirectory = originalContentRoot;
 #else
-rootDirectoryField.SetValue(contentManager, originalContentRoot);
-fullRootDirectoryField.SetValue(contentManager, originalContentRoot);
+    rootDirectoryField.SetValue(contentManager, originalContentRoot);
+    fullRootDirectoryField.SetValue(contentManager, originalContentRoot);
 #endif
     }
 

--- a/TextParseReturnValue.cs
+++ b/TextParseReturnValue.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using Microsoft.Xna.Framework.Graphics;
 using System.Text;
 
 namespace Rampastring.XNAUI;
@@ -16,7 +15,7 @@ public class TextParseReturnValue
         LineCount = lineCount;
     }
 
-    public static TextParseReturnValue FixText(SpriteFont spriteFont, int width, string text)
+    public static TextParseReturnValue FixText(IFont font, int width, string text)
     {
         string line = string.Empty;
         int lineCount = 0;
@@ -25,7 +24,7 @@ public class TextParseReturnValue
 
         foreach (string word in wordArray)
         {
-            if (spriteFont.MeasureString(line + word).Length() > width)
+            if (font.MeasureString(line + word).X > width)
             {
                 processedText = processedText + line + Environment.NewLine;
                 lineCount++;
@@ -39,7 +38,7 @@ public class TextParseReturnValue
         return new TextParseReturnValue(processedText, lineCount);
     }
 
-    public static List<string> GetFixedTextLines(SpriteFont spriteFont, int width, string text, bool splitWords = true, bool keepBlankLines = false)
+    public static List<string> GetFixedTextLines(IFont font, int width, string text, bool splitWords = true, bool keepBlankLines = false)
     {
         if (string.IsNullOrEmpty(text))
             return new List<string>(0);
@@ -60,7 +59,7 @@ public class TextParseReturnValue
 
             foreach (string word in wordArray)
             {
-                if (spriteFont.MeasureString(line + word).X > width)
+                if (font.MeasureString(line + word).X > width)
                 {
                     if (line.Length > 0)
                     {
@@ -68,13 +67,13 @@ public class TextParseReturnValue
                     }
 
                     // Split individual words that are longer than the allowed width
-                    if (splitWords && spriteFont.MeasureString(word).X > width)
+                    if (splitWords && font.MeasureString(word).X > width)
                     {
                         var sb = new StringBuilder();
 
                         for (int i = 0; i < word.Length; i++)
                         {
-                            if (spriteFont.MeasureString(sb.ToString() + word[i]).X > width)
+                            if (font.MeasureString(sb.ToString() + word[i]).X > width)
                             {
                                 returnValue.Add(sb.ToString());
                                 sb.Clear();


### PR DESCRIPTION
Todo:

- [ ] Make XNATextbox surrogate aware (currently errors if you try moving the carat through unicode text).
- [ ] (?) Add [markup](https://github.com/FontStashSharp/FontStashSharp/wiki/Rich-Text) support.

----

Adds support for TTF fonts using [FontStashSharp](https://github.com/FontStashSharp/FontStashSharp)

Retains support for the old fonts.

Fonts are now defined in Fonts.ini (located any of the asset paths). A file might look like this:

```
[Fonts]
Count=9

[Font0]
Type=TrueType
Path=MozillaText-SemiBold.ttf
Size=15

[Font1]
Type=TrueType
Path=MozillaText-SemiBold.ttf
Size=15

[Font2]
Type=TrueType
Path=MozillaText-SemiBold.ttf
Size=18

[Font3]
Type=TrueType
Path=MozillaText-SemiBold.ttf
Size=22

[Font4]
Type=SpriteFont
Path=SpriteFont0.xnb

[Font5]
Type=SpriteFont
Path=SpriteFont1.xnb

[Font6]
Type=SpriteFont
Path=SpriteFont2.xnb

[Font7]
Type=SpriteFont
Path=SpriteFont3.xnb

[Font8]
Type=SpriteFont
Path=SpriteFont4.xnb

```


Preview:
<img width="1602" height="932" alt="image" src="https://github.com/user-attachments/assets/2bb9a576-c9f9-4b5b-992d-f1afd54ac9c7" />
