### PR TITLE
Fix selection bug in XNASuggestionTextBox

### DIFF
--- a/XNAControls/XNASuggestionTextBox.cs
+++ b/XNAControls/XNASuggestionTextBox.cs
@@ -52,7 +52,11 @@ public class XNASuggestionTextBox : XNATextBox
         if (WindowManager.SelectedControl == this)
         {
             if (Text == Suggestion)
+            {
                 Text = string.Empty;
+                ResetMouseTracking();
+            }
+
         }
         else
         {

--- a/XNAControls/XNASuggestionTextBox.cs
+++ b/XNAControls/XNASuggestionTextBox.cs
@@ -56,7 +56,6 @@ public class XNASuggestionTextBox : XNATextBox
                 Text = string.Empty;
                 ResetMouseTracking();
             }
-
         }
         else
         {

--- a/XNAControls/XNATextBox.cs
+++ b/XNAControls/XNATextBox.cs
@@ -708,6 +708,12 @@ public class XNATextBox : XNAControl
                     FontIndex).X < Width - TEXT_HORIZONTAL_MARGIN * 2;
     }
 
+    protected void ResetMouseTracking()
+    {
+        isMouseLocked = false;
+        mouseDownCharacterIndex = 0;
+    }
+
     private void UpdateCursorState()
     {
         if (isMouseLocked)


### PR DESCRIPTION
Fixes the issue where clicking and dragging in a suggestion textbox would retain the mouseDownCharacterIndex and cause a selection when the character count gets to mouseDownCharacterIndex.