### PR TITLE
Further reduce AssetLoader.TextureFromImage() overhead

### DIFF
--- a/AssetLoader.cs
+++ b/AssetLoader.cs
@@ -7,7 +7,7 @@ using Rampastring.Tools;
 using Microsoft.Xna.Framework.Content;
 using Microsoft.Xna.Framework.Media;
 using SixLabors.ImageSharp;
-using SixLabors.ImageSharp.Formats.Png;
+using SixLabors.ImageSharp.Formats.Bmp;
 using Color = Microsoft.Xna.Framework.Color;
 using System.Globalization;
 
@@ -214,7 +214,7 @@ public static class AssetLoader
         try
         {
             using var stream = new MemoryStream();
-            image.Save(stream, new PngEncoder() { CompressionLevel = PngCompressionLevel.NoCompression });
+            image.Save(stream, new BmpEncoder() { BitsPerPixel = BmpBitsPerPixel.Pixel32, SupportTransparency = true });
             var texture = Texture2D.FromStream(graphicsDevice, stream);
             PremultiplyAlpha(texture);
             return texture;


### PR DESCRIPTION
Even with PNG Compression level 0 specified, this image saving process still takes notably overhead (~ 60ms for a regular map preview image), and therefore causes laggy. Considering that this MemoryStream only holds the saved image for a very short time during loading, which means it's only a temporary image, this PR uses 32-bit BMP to replace PNG.

Before
<img width="2072" height="1485" alt="Snipaste_2026-04-09_19-50-50" src="https://github.com/user-attachments/assets/95c1c38b-a874-42b5-b4a7-618d6ecb9791" />

Now
<img width="2079" height="1494" alt="Snipaste_2026-04-09_19-53-00" src="https://github.com/user-attachments/assets/a067b1aa-37d4-4836-9048-f9e89f9f294f" />
